### PR TITLE
fix(light-theme/diff-colors): contrast too low

### DIFF
--- a/lua/vscode/colors.lua
+++ b/lua/vscode/colors.lua
@@ -85,10 +85,10 @@ local generate = function ()
 			vscSelection = '#ADD6FF',
 			vscLineNumber = '#098658',
 
-      vscDiffRedDark = '#FFCCCC',
-      vscDiffRedLight = '#FFA3A3',
+			vscDiffRedDark = '#FFCCCC',
+			vscDiffRedLight = '#FFA3A3',
 			vscDiffRedLightLight = '#FFCCCC',
-      vscDiffGreenDark = '#DBE6C2',
+			vscDiffGreenDark = '#DBE6C2',
 			vscDiffGreenLight = '#EBF1DD',
 			vscSearchCurrent = '#A8AC94',
 			vscSearch = '#F8C9AB',


### PR DESCRIPTION
## Description
Fixes #12. This is done by following VSCode default light theme diff color:
![image](https://user-images.githubusercontent.com/23183656/138201588-1bd39213-a333-438f-876a-cb1d93f87049.png)

## Screenshots
|Before|After|
|--|--|
|![image](https://user-images.githubusercontent.com/23183656/138201462-a08cdb6e-2abe-4048-993c-0ba4607bfe80.png)|![image](https://user-images.githubusercontent.com/23183656/138201396-92617599-7712-413a-9cac-cd794a265973.png)|