### PR TITLE
feat: update LSP reference color

### DIFF
--- a/lua/vscode/colors.lua
+++ b/lua/vscode/colors.lua
@@ -17,7 +17,7 @@ local generate = function()
 			vscPopupFront = '#BBBBBB',
 			vscPopupBack = '#2D2D30',
 			vscPopupHighlightBlue = '#073655',
-			vscPopupHighlightGray = '#3D3D40',
+			vscPopupHighlightGray = '#343B41',
 
 			vscSplitLight = '#898989',
 			vscSplitDark = '#444444',

--- a/lua/vscode/theme.lua
+++ b/lua/vscode/theme.lua
@@ -417,9 +417,9 @@ theme.load_syntax = function()
 		DiagnosticUnderlineWarn = { nil, nil, 'undercurl', c.vscYellow },
 		DiagnosticUnderlineInfo = { nil, nil, 'undercurl', c.vscBlue },
 		DiagnosticUnderlineHint = { nil, nil, 'undercurl', c.vscBlue },
-		LspReferenceText = { c.vscYellowOrange, nil, 'none', nil },
-		LspReferenceRead = { c.vscYellowOrange, nil, 'none', nil },
-		LspReferenceWrite = { c.vscYellowOrange, nil, 'none', nil },
+		LspReferenceText = { nil, c.vscPopupHighlightGray, 'none', nil },
+		LspReferenceRead = { nil, c.vscPopupHighlightGray, 'none', nil },
+		LspReferenceWrite = { nil, c.vscPopupHighlightGray, 'none', nil },
 	}
 
 	if vim.g.vscode_style == 'dark' then


### PR DESCRIPTION
Update the LSP reference color according to the VSCode Dark+ reference

**Before**
![image](https://user-images.githubusercontent.com/43115371/143423254-f543ae57-d9b7-4f41-bfa3-f31854a4e882.png)

**After**
![image](https://user-images.githubusercontent.com/43115371/143423005-3958dd96-71eb-4b62-8352-5f7aff7ba57f.png)

**Reference**
![image](https://user-images.githubusercontent.com/43115371/143423488-69144670-cbdd-4500-a749-b01f546df686.png)

