### PR TITLE
Add transparency

### DIFF
--- a/lua/vscode/colors.lua
+++ b/lua/vscode/colors.lua
@@ -110,6 +110,10 @@ local generate = function()
 		}
 	end
 
+	if vim.g.vscode_transparent then
+		colors.vscBack = 'NONE'
+	end
+
 	return colors
 end
 


### PR DESCRIPTION
When you have transparency set on your terminal, it gets rid of its transparency without this

allows for creating a global variable g:vscode_transparent to make background transparent