### PR TITLE
refactor: check vscode_style one time only

### DIFF
--- a/lua/vscode/theme.lua
+++ b/lua/vscode/theme.lua
@@ -3,6 +3,7 @@ local theme = {}
 
 theme.load_syntax = function()
     local c = colors.generate()
+    local isDark = vim.g.vscode_style == 'dark'
     local syntax = {
         -- GROUP, FOREGROUND, BACKGROUND, ATTRIBUTE, SPECIAL
         Normal = { c.vscFront, c.vscBack, 'none', nil },
@@ -30,7 +31,7 @@ theme.load_syntax = function()
         NonText = { c.vscLineNumber, c.vscBack, 'none', nil },
         Pmenu = { c.vscPopupFront, c.vscPopupBack, 'none', nil },
         PmenuSel = {
-            vim.g.vscode_style == 'dark' and c.vscPopupFront or c.vscBack,
+            isDark and c.vscPopupFront or c.vscBack,
             c.vscPopupHighlightBlue,
             'none',
             nil,
@@ -89,7 +90,7 @@ theme.load_syntax = function()
         SpellCap = { c.vscRed, c.vscBack, 'undercurl', c.vscRed },
         SpellRare = { c.vscRed, c.vscBack, 'undercurl', c.vscRed },
         SpellLocal = { c.vscRed, c.vscBack, 'undercurl', c.vscRed },
-        Whitespace = { vim.g.vscode_style == 'dark' and c.vscLineNumber or c.vscTabOther, nil, 'none', nil },
+        Whitespace = { isDark and c.vscLineNumber or c.vscTabOther, nil, 'none', nil },
 
         -- Treesitter
         TSError = { c.vscRed, nil, 'none', nil },
@@ -135,40 +136,40 @@ theme.load_syntax = function()
         TSTag = { c.vscBlue, nil, 'none', nil },
         TSTagDelimiter = { c.vscGray, nil, 'none', nil },
 
-        TSTitle = { vim.g.vscode_style == 'dark' and c.vscBlue or c.vscYellowOrange, nil, 'bold', nil },
+        TSTitle = { isDark and c.vscBlue or c.vscYellowOrange, nil, 'bold', nil },
         TSLiteral = { c.vscFront, 'none', nil },
         TSEmphasis = { c.vscFront, nil, 'italic', nil },
-        TSStrong = { vim.g.vscode_style == 'dark' and c.vscBlue or c.vscViolet, nil, 'bold', nil },
+        TSStrong = { isDark and c.vscBlue or c.vscViolet, nil, 'bold', nil },
         TSURI = { c.vscFront, nil, 'none', nil },
-        TSTextReference = { vim.g.vscode_style == 'dark' and c.vscOrange or c.vscYellowOrange, nil, 'none', nil },
+        TSTextReference = { isDark and c.vscOrange or c.vscYellowOrange, nil, 'none', nil },
         TSPunctDelimiter = { c.vscFront, nil, 'none', nil },
-        TSStringEscape = { vim.g.vscode_style == 'dark' and c.vscOrange or c.vscYellowOrange, nil, 'bold', nil },
+        TSStringEscape = { isDark and c.vscOrange or c.vscYellowOrange, nil, 'bold', nil },
 
         TSNote = { c.vscBlueGreen, nil, 'bold', nil },
         TSWarning = { c.vscYellowOrange, nil, 'bold', nil },
         TSDanger = { c.vscRed, nil, 'bold', nil },
 
         -- Markdown
-        markdownBold = { vim.g.vscode_style == 'dark' and c.vscBlue or c.vscYellowOrange, nil, 'bold', nil },
+        markdownBold = { isDark and c.vscBlue or c.vscYellowOrange, nil, 'bold', nil },
         markdownCode = { c.vscOrange, nil, 'none', nil },
-        markdownRule = { vim.g.vscode_style == 'dark' and c.vscBlue or c.vscYellowOrange, nil, 'bold', nil },
+        markdownRule = { isDark and c.vscBlue or c.vscYellowOrange, nil, 'bold', nil },
         markdownCodeDelimiter = { c.vscFront, nil, 'none', nil },
         markdownHeadingDelimiter = {
-            vim.g.vscode_style == 'dark' and c.vscBlue or c.vscYellowOrange,
+            isDark and c.vscBlue or c.vscYellowOrange,
             nil,
             'none',
             nil,
         },
-        markdownFootnote = { vim.g.vscode_style == 'dark' and c.vscOrange or c.vscYellowOrange, nil, 'none', nil },
+        markdownFootnote = { isDark and c.vscOrange or c.vscYellowOrange, nil, 'none', nil },
         markdownFootnoteDefinition = {
-            vim.g.vscode_style == 'dark' and c.vscOrange or c.vscYellowOrange,
+            isDark and c.vscOrange or c.vscYellowOrange,
             nil,
             'none',
             nil,
         },
         markdownUrl = { c.vscFront, nil, 'underline', nil },
-        markdownLinkText = { vim.g.vscode_style == 'dark' and c.vscOrange or c.vscYellowOrange, nil, 'none', nil },
-        markdownEscape = { vim.g.vscode_style == 'dark' and c.vscOrange or c.vscYellowOrange, nil, 'none', nil },
+        markdownLinkText = { isDark and c.vscOrange or c.vscYellowOrange, nil, 'none', nil },
+        markdownEscape = { isDark and c.vscOrange or c.vscYellowOrange, nil, 'none', nil },
 
         -- JSON
         jsonKeyword = { c.vscLightBlue, nil, 'none', nil },
@@ -450,19 +451,19 @@ theme.load_syntax = function()
         IndentBlanklineContextChar = { c.vscRed, nil, 'nocombine', nil },
         IndentBlanklineContextStart = { c.vscRed, nil, 'nocombine', nil },
         IndentBlanklineChar = {
-            vim.g.vscode_style == 'dark' and c.vscLineNumber or c.vscTabOther,
+            isDark and c.vscLineNumber or c.vscTabOther,
             nil,
             'nocombine',
             nil,
         },
         IndentBlanklineSpaceChar = {
-            vim.g.vscode_style == 'dark' and c.vscLineNumber or c.vscTabOther,
+            isDark and c.vscLineNumber or c.vscTabOther,
             nil,
             'nocombine',
             nil,
         },
         IndentBlanklineSpaceCharBlankline = {
-            vim.g.vscode_style == 'dark' and c.vscLineNumber or c.vscTabOther,
+            isDark and c.vscLineNumber or c.vscTabOther,
             nil,
             'nocombine',
             nil,
@@ -493,14 +494,14 @@ theme.load_syntax = function()
         CmpItemKindConstructor = { c.vscUiOrange, nil, 'none', nil },
         CmpItemAbbrDeprecated = { c.vscCursorDark, c.vscPopupBack, 'strikethrough', nil },
         CmpItemAbbrMatch = {
-            vim.g.vscode_style == 'dark' and c.vscBlue or c.vscDarkBlue,
+            isDark and c.vscBlue or c.vscDarkBlue,
             c.vscPopupBack,
             'bold',
             nil,
         },
     }
 
-    if vim.g.vscode_style == 'dark' then
+    if isDark then
         syntax.NvimTreeFolderIcon = { c.vscBlue, nil, 'none', nil }
         syntax.NvimTreeIndentMarker = { c.vscLineNumber, nil, 'none', nil }
 


### PR DESCRIPTION
Check the vscode_style once and save the result to the local variable. This changes make code more efficient and more readable.