### PR TITLE
feat: add Xresources config extra

### DIFF
--- a/extra/Xresources/vscode-dark
+++ b/extra/Xresources/vscode-dark
@@ -1,0 +1,22 @@
+! vscode dark .Xresources
+
+*.foreground: #d4d4d4
+*.background: #1e1e1e
+*.cursorColor: #d4d4d4
+
+*.color0: #1e1e1e
+*.color1: #f44747
+*.color2: #608b4e
+*.color3: #dcdcaa
+*.color4: #569cd6
+*.color5: #c678dd
+*.color6: #56b6c2
+*.color7: #d4d4d4
+*.color8: #808080
+*.color9: #f44747
+*.color10: #608b4e
+*.color11: #dcdcaa
+*.color12: #569cd6
+*.color13: #c678dd
+*.color14: #56b6c2
+*.color15: #d4d4d4

--- a/extra/Xresources/vscode-light
+++ b/extra/Xresources/vscode-light
@@ -1,0 +1,22 @@
+! vscode light .Xresources
+
+*.foreground: #000000
+*.background: #ffffff
+*.cursorColor: #000000
+
+*.color0: #ffffff
+*.color1: #c72e0f
+*.color2: #008000
+*.color3: #795e25
+*.color4: #007acc
+*.color5: #af00db
+*.color6: #56b6c2
+*.color7: #000000
+*.color8: #808080
+*.color9: #c72e0f
+*.color10: #008000
+*.color11: #795e25
+*.color12: #007acc
+*.color13: #af00db
+*.color14: #56b6c2
+*.color15: #000000


### PR DESCRIPTION
Add .Xresources config extra for X11 terminal emulators and other programs that can read these values.
https://wiki.archlinux.org/title/X_resources

Example with `htop` open in `st` terminal emulator:
![VirtualBoxVM_w9wx1hq3zF](https://user-images.githubusercontent.com/52537705/155201043-1205ba76-0dd7-4571-ae21-1bee246d4a1c.png)

