### PR TITLE
fix(xml): fix xml colorscheme

### DIFF
--- a/lua/vscode/theme.lua
+++ b/lua/vscode/theme.lua
@@ -310,9 +310,9 @@ theme.load_syntax = function()
         typescriptPromiseMethod = { c.vscYellow, nil, 'none', nil },
 
         -- XML
-        xmlTag = { c.vscBlueGreen, nil, 'none', nil },
-        xmlTagName = { c.vscBlueGreen, nil, 'none', nil },
-        xmlEndTag = { c.vscBlueGreen, nil, 'none', nil },
+        xmlTag = { c.vscBlue, nil, 'none', nil },
+        xmlTagName = { c.vscBlue, nil, 'none', nil },
+        xmlEndTag = { c.vscBlue, nil, 'none', nil },
 
         -- Ruby
         rubyClassNameTag = { c.vscBlueGreen, nil, 'none', nil },


### PR DESCRIPTION
The colors for xml are not matching with vscode ones 

![Screenshot 2022-03-01 at 08 24 40](https://user-images.githubusercontent.com/52538691/156124488-978642d7-dbd3-44d4-9a22-2dd328448ba7.png)
