### PR TITLE
feat: add zathura document viewer color scheme extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,9 @@ require'bufferline'.setup{
 ## 🍭 Extra folder
 - [Kitty](https://sw.kovidgoyal.net/kitty/) color scheme
 - [Alacritty](https://github.com/alacritty/alacritty) color scheme
+- [Xresources](https://wiki.debian.org/Xresources) color scheme
 - [galaxyline.nvim](https://github.com/glepnir/galaxyline.nvim) theme
+- [zathura](https://pwmt.org/projects/zathura/) color scheme
 
 
 

--- a/extra/zathura/vscode-dark
+++ b/extra/zathura/vscode-dark
@@ -1,0 +1,37 @@
+# vscode dark zathura colorscheme
+
+set default-bg                  "#1e1e1e"
+set default-fg                  "#d4d4d4"
+
+set statusbar-bg                "#1e1e1e"
+set statusbar-fg                "#808080"
+
+set inputbar-bg                 "#1e1e1e"
+set inputbar-fg                 "#d4d4d4"
+
+set notification-error-bg       "#1e1e1e"
+set notification-error-fg       "#f44747"
+
+set notification-warning-bg     "#1e1e1e"
+set notification-warning-fg     "#d7ba7d"
+
+set highlight-color             "#007acc"
+set highlight-active-color      "#d4d4d4"
+
+set completion-highlight-fg     "#56b6c2"
+set completion-highlight-bg     false
+
+set completion-bg               "#1e1e1e"
+set completion-fg               "#d4d4d4"
+
+set notification-bg             "#1e1e1e"
+set notification-fg             "#d4d4d4"
+
+set recolor-lightcolor          "#1e1e1e"
+set recolor-darkcolor           "#d4d4d4"
+
+set index-fg                    "#d4d4d4"
+set index-bg                    "#1e1e1e"
+
+set index-active-fg             "#56b6c2"
+set index-active-bg             false

--- a/extra/zathura/vscode-light
+++ b/extra/zathura/vscode-light
@@ -1,0 +1,37 @@
+# vscode light zathura colorscheme
+
+set default-bg                  "#ffffff"
+set default-fg                  "#1e1e1e"
+
+set statusbar-bg                "#ffffff"
+set statusbar-fg                "#808080"
+
+set inputbar-bg                 "#ffffff"
+set inputbar-fg                 "#000000"
+
+set notification-error-bg       "#ffffff"
+set notification-error-fg       "#c72e0f"
+
+set notification-warning-fg     "#795e25"
+set notification-warning-bg     "#ffffff"
+
+set highlight-color             "#007acc"
+set highlight-active-color      "#808080"
+
+set completion-highlight-bg     "#56b6c2"
+set completion-highlight-fg     "#000000"
+
+set completion-bg               "#ffffff"
+set completion-fg               "#000000"
+
+set notification-bg             "#ffffff"
+set notification-fg             "#000000"
+
+set recolor-lightcolor          "#ffffff"
+set recolor-darkcolor           "#1e1e1e"
+
+set index-bg                    "#ffffff"
+set index-fg                    "#000000"
+
+set index-active-fg             "#000000"
+set index-active-bg             "#56b6c2"


### PR DESCRIPTION
Color scheme extra for zathura document viewer (https://pwmt.org/projects/zathura/).
![VirtualBoxVM_h4NJ8RiRnW](https://user-images.githubusercontent.com/52537705/156441322-08295790-39f3-462c-8f82-c176dd7ef477.png)
![VirtualBoxVM_iHmtdJGEQ7](https://user-images.githubusercontent.com/52537705/156441325-9d058563-db1a-4064-90ba-fbdd6b5ca53b.png)

