### PR TITLE
fix: fix indent-blankline.nvim color

### DIFF
--- a/lua/vscode/colors.lua
+++ b/lua/vscode/colors.lua
@@ -37,6 +37,9 @@ local generate = function()
             vscSearchCurrent = '#4B5632',
             vscSearch = '#264F78',
 
+            vscContext = '#404040',
+            vscContextCurrent = '#707070',
+
             -- Syntax colors
             vscGray = '#808080',
             vscViolet = '#646695',
@@ -90,6 +93,9 @@ local generate = function()
             vscDiffGreenLight = '#EBF1DD',
             vscSearchCurrent = '#A8AC94',
             vscSearch = '#F8C9AB',
+
+            vscContext = '#D2D2D2',
+            vscContextCurrent = '#929292',
 
             -- Syntax colors
             vscGray = '#000000',

--- a/lua/vscode/theme.lua
+++ b/lua/vscode/theme.lua
@@ -412,7 +412,7 @@ theme.load_syntax = function()
         GitSignsAddLn = { c.vscBack, c.vscGreen, 'none', nil },
         GitSignsChangeLn = { c.vscBack, c.vscYellow, 'none', nil },
         GitSignsDeleteLn = { c.vscBack, c.vscRed, 'none', nil },
-        
+
         -- NvimTree
         NvimTreeRootFolder = { c.vscFront, nil, 'bold', nil },
         NvimTreeGitDirty = { c.vscYellow, nil, 'none', nil },
@@ -451,26 +451,11 @@ theme.load_syntax = function()
         BufferTabpagesFill = { c.vscFront, c.vscTabOther, 'none', nil },
 
         -- IndentBlankLine
-        IndentBlanklineContextChar = { c.vscRed, nil, 'nocombine', nil },
-        IndentBlanklineContextStart = { c.vscRed, nil, 'nocombine', nil },
-        IndentBlanklineChar = {
-            isDark and c.vscLineNumber or c.vscTabOther,
-            nil,
-            'nocombine',
-            nil,
-        },
-        IndentBlanklineSpaceChar = {
-            isDark and c.vscLineNumber or c.vscTabOther,
-            nil,
-            'nocombine',
-            nil,
-        },
-        IndentBlanklineSpaceCharBlankline = {
-            isDark and c.vscLineNumber or c.vscTabOther,
-            nil,
-            'nocombine',
-            nil,
-        },
+        IndentBlanklineContextChar = { c.vscContextCurrent, nil, 'nocombine', nil },
+        IndentBlanklineContextStart = { c.vscContextCurrent, nil, 'nocombine', nil },
+        IndentBlanklineChar = { c.vscContext, nil, 'nocombine', nil },
+        IndentBlanklineSpaceChar = { c.vscContext, nil, 'nocombine', nil },
+        IndentBlanklineSpaceCharBlankline = { c.vscContext, nil, 'nocombine', nil },
 
         -- LSP
         DiagnosticError = { c.vscRed, nil, 'none', nil },


### PR DESCRIPTION
### Old color
**Dark theme**
![old_dark](https://user-images.githubusercontent.com/43115371/161885550-59cf2d49-aa9d-406c-ba8f-a7fd6fc0b486.png)

**Light theme**
![old_white](https://user-images.githubusercontent.com/43115371/161885581-ea5babba-cb59-42e1-b298-29e5a0865c17.png)


### New color
**Dark theme**
![new_dark](https://user-images.githubusercontent.com/43115371/161885699-d06ebeb7-a427-4c6b-90cf-4be9e61591ab.png)

**Light theme**
![new_light](https://user-images.githubusercontent.com/43115371/161885737-6aa444c6-bf39-4e7f-83e7-f3da88c44128.png)


### VSCode reference
**Dark theme**
![vscode_dark](https://user-images.githubusercontent.com/43115371/161885751-1e032861-582f-4663-95f1-72e27903dcdc.png)

**Light theme*
![vscode_light](https://user-images.githubusercontent.com/43115371/161885761-71a3a303-d318-48b1-8831-8563fcb31c8b.png)
*