### PR TITLE
feat: update nvim-cmp highlight

### DIFF
--- a/lua/vscode/theme.lua
+++ b/lua/vscode/theme.lua
@@ -480,10 +480,18 @@ theme.load_syntax = function()
         CmpItemKindProperty = { c.vscFront, nil, 'none', nil },
         CmpItemKindUnit = { c.vscFront, nil, 'none', nil },
         CmpItemKindConstructor = { c.vscUiOrange, nil, 'none', nil },
+        CmpItemMenu = { c.vscPopupFront, nil, 'none', nil },
+        CmpItemAbbr = { c.vscFront, nil, 'none', nil },
         CmpItemAbbrDeprecated = { c.vscCursorDark, c.vscPopupBack, 'strikethrough', nil },
         CmpItemAbbrMatch = {
-            isDark and c.vscBlue or c.vscDarkBlue,
-            c.vscPopupBack,
+            isDark and c.vscMediumBlue or c.vscDarkBlue,
+            nil,
+            'bold',
+            nil,
+        },
+        CmpItemAbbrMatchFuzzy = {
+            isDark and c.vscMediumBlue or c.vscDarkBlue,
+            nil,
             'bold',
             nil,
         },
@@ -583,7 +591,6 @@ theme.link_highlight = function()
     vim.api.nvim_command('highlight link CompeDocumentation Pmenu')
     vim.api.nvim_command('highlight link CompeDocumentationBorder Pmenu')
     vim.api.nvim_command('highlight link CmpItemKind Pmenu')
-    vim.api.nvim_command('highlight link CmpItemAbbr Pmenu')
     vim.api.nvim_command('highlight link CmpItemKindClass CmpItemKindConstructor')
     vim.api.nvim_command('highlight link CmpItemKindModule CmpItemKindKeyword')
     vim.api.nvim_command('highlight link CmpItemKindOperator TSOperator')


### PR DESCRIPTION
### Old
![old](https://user-images.githubusercontent.com/43115371/164397199-61c9b80a-b6d3-453c-8118-650544a032a0.png)

### New
![new](https://user-images.githubusercontent.com/43115371/164397266-11a30dc8-686a-4a38-af64-4cb869e480ce.png)

### VSCode reference
![vscode](https://user-images.githubusercontent.com/43115371/164397338-1788e9e5-780e-472f-b3f7-8a0ba917ff54.png)

I tried to make it look the same as VSCode as much as possible, but there is some limitation. The selected option's text should be a little bit brighter than the other options.
