### PR TITLE
feat: using default vim variable to set dark or light variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ Plug 'Mofiqul/vscode.nvim'
 
 ```lua
 -- Lua:
--- For dark theme
-vim.g.vscode_style = "dark"
+-- For dark theme (default for neovim)
+vim.o.background = "dark"
 -- For light theme
-vim.g.vscode_style = "light"
+vim.o.background = "light"
 -- Enable transparent background
 vim.g.vscode_transparent = 1
 -- Enable italic comment

--- a/extra/galaxyline/galaxyline.lua
+++ b/extra/galaxyline/galaxyline.lua
@@ -4,7 +4,7 @@ local status_line = {}
 local colors = {}
 
 colors.fg = function()
-    if vim.g.vscode_style == 'dark' then
+    if vim.o.background == 'dark' then
         return '#ffffff'
     else
         return '#343434'
@@ -12,7 +12,7 @@ colors.fg = function()
 end
 
 colors.bg = function()
-    if vim.g.vscode_style == 'dark' then
+    if vim.o.background == 'dark' then
         return '#252526'
     else
         return '#f3f3f3'
@@ -20,7 +20,7 @@ colors.bg = function()
 end
 
 colors.green = function()
-    if vim.g.vscode_style == 'dark' then
+    if vim.o.background == 'dark' then
         return '#619955'
     else
         return '#008000'
@@ -28,7 +28,7 @@ colors.green = function()
 end
 
 colors.bluegreen = function()
-    if vim.g.vscode_style == 'dark' then
+    if vim.o.background == 'dark' then
         return '#4ec9b0'
     else
         return '#16825d'
@@ -36,7 +36,7 @@ colors.bluegreen = function()
 end
 
 colors.yellow = function()
-    if vim.g.vscode_style == 'dark' then
+    if vim.o.background == 'dark' then
         return '#ffaf00'
     else
         return '#795e26'
@@ -44,7 +44,7 @@ colors.yellow = function()
 end
 
 colors.pink = function()
-    if vim.g.vscode_style == 'dark' then
+    if vim.o.background == 'dark' then
         return '#c586c0'
     else
         return '#af00db'

--- a/lua/lualine/themes/vscode.lua
+++ b/lua/lualine/themes/vscode.lua
@@ -3,7 +3,7 @@
 local vscode = {}
 local colors = {}
 
-if vim.g.vscode_style == "dark" then
+if vim.o.background == "dark" then
     colors.bg = "#262626"
     colors.bg2 = "#373737"
     colors.fg = "#ffffff"
@@ -27,7 +27,7 @@ end
 
 vscode.normal = {
     b = {fg = colors.blue, bg = colors.bg2},
-    a = {fg = vim.g.vscode_style == "dark" and colors.fg or colors.bg, bg = colors.blue, gui = "bold"},
+    a = {fg = vim.o.background == "dark" and colors.fg or colors.bg, bg = colors.blue, gui = "bold"},
     c = {fg = colors.fg, bg = colors.bg}
 }
 
@@ -43,19 +43,19 @@ vscode.inactive = {
 
 vscode.replace = {
     b = {fg = colors.red, bg = colors.bg2},
-    a = {fg = vim.g.vscode_style == "dark" and colors.bg or colors.fg, bg = colors.red, gui = "bold"},
+    a = {fg = vim.o.background == "dark" and colors.bg or colors.fg, bg = colors.red, gui = "bold"},
     c = {fg = colors.fg, bg = colors.bg}
 }
 
 vscode.insert = {
-    a = {fg = vim.g.vscode_style == "dark" and colors.bg or colors.fg, bg = colors.green, gui = "bold"},
+    a = {fg = vim.o.background == "dark" and colors.bg or colors.fg, bg = colors.green, gui = "bold"},
     b = {fg = colors.green, bg = colors.bg2},
     c = {fg = colors.fg, bg = colors.bg}
 }
 
 vscode.command = {
     b = {fg = colors.pink, bg = colors.bg2},
-    a = {fg = vim.g.vscode_style == "dark" and colors.bg or colors.fg, bg = colors.pink, gui = "bold"},
+    a = {fg = vim.o.background == "dark" and colors.bg or colors.fg, bg = colors.pink, gui = "bold"},
     c = {fg = colors.fg, bg = colors.bg}
 }
 

--- a/lua/vscode/colors.lua
+++ b/lua/vscode/colors.lua
@@ -1,6 +1,6 @@
 local generate = function()
     local colors = {}
-    if vim.g.vscode_style == 'dark' then
+    if vim.o.background == 'dark' then
         colors = {
             vscNone = 'NONE',
             vscFront = '#D4D4D4',

--- a/lua/vscode/init.lua
+++ b/lua/vscode/init.lua
@@ -10,7 +10,7 @@ vscode.set = function()
 end
 
 vscode.change_style = function(style)
-    vim.g.vscode_style = style
+    vim.o.background = style
     print('Vscode style: ', style)
     vim.cmd([[colorscheme vscode]])
 end

--- a/lua/vscode/theme.lua
+++ b/lua/vscode/theme.lua
@@ -3,7 +3,7 @@ local theme = {}
 
 theme.load_syntax = function()
     local c = colors.generate()
-    local isDark = vim.g.vscode_style == 'dark'
+    local isDark = vim.o.background == 'dark'
     local isItalic = vim.g.vscode_italic_comment == 1
     local no_nvimtree_bg = vim.g.vscode_disable_nvimtree_bg == true
     local syntax = {

--- a/lua/vscode/utils.lua
+++ b/lua/vscode/utils.lua
@@ -16,7 +16,6 @@ utils.load = function()
         vim.cmd('syntax reset')
     end
 
-    vim.o.background = 'dark'
     vim.o.termguicolors = true
     vim.g.colors_name = 'vscode'
 


### PR DESCRIPTION
Instead of using a separate variable to set the dark or light variants, we can use the default vim variable to set it.

Everything works as expected, even the function to change the theme on the fly.
```
:lua require('vscode').change_style("light")
:lua require('vscode').change_style("dark")
``` 