### PR TITLE
fix: correct markdown inline code highlight

### DIFF
--- a/lua/vscode/theme.lua
+++ b/lua/vscode/theme.lua
@@ -141,6 +141,7 @@ theme.load_syntax = function()
 
         TSTitle = { isDark and c.vscBlue or c.vscYellowOrange, nil, 'bold', nil },
         TSLiteral = { c.vscFront, 'none', nil },
+        markdownTSLiteral = { c.vscOrange, 'none', nil },
         TSEmphasis = { c.vscFront, nil, 'italic', nil },
         TSStrong = { isDark and c.vscBlue or c.vscViolet, nil, 'bold', nil },
         TSURI = { c.vscFront, nil, 'none', nil },


### PR DESCRIPTION
This PR fixes https://github.com/Mofiqul/vscode.nvim/issues/37

![image](https://user-images.githubusercontent.com/43115371/175901170-cef27a7f-ad27-4ac8-b2a3-31528aacedeb.png)
