### PR TITLE
fix: correct markdown_inline highlight color

### DIFF
--- a/lua/vscode/theme.lua
+++ b/lua/vscode/theme.lua
@@ -142,6 +142,7 @@ theme.load_syntax = function()
         TSTitle = { isDark and c.vscBlue or c.vscYellowOrange, nil, 'bold', nil },
         TSLiteral = { c.vscFront, 'none', nil },
         markdownTSLiteral = { c.vscOrange, 'none', nil },
+        markdown_inlineTSLiteral = { c.vscOrange, 'none', nil },
         TSEmphasis = { c.vscFront, nil, 'italic', nil },
         TSStrong = { isDark and c.vscBlue or c.vscViolet, nil, 'bold', nil },
         TSURI = { c.vscFront, nil, 'none', nil },


### PR DESCRIPTION
This PR fixed the inline-code highlight color for the latest markdown parser

see the detail in  https://github.com/Mofiqul/vscode.nvim/pull/65#issuecomment-1168493944