### PR TITLE
docs: fix readme example higroup override

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ require('vscode').setup({
     }
 
     -- Override highlight groups (see ./lua/vscode/theme.lua)
-    color_overrides = {
+    group_overrides = {
         -- this supports the same val table as vim.api.nvim_set_hl
         -- use colors from this colorscheme by requiring vscode.colors!
         Cursor = { fg=c.vscDarkBlue, bg=c.vscLightGreen, bold=true },


### PR DESCRIPTION
Minor issue I spotted when updating my theme config to use `require('vscode').setup`.

Second README example should be `group_overrides`.

https://github.com/Mofiqul/vscode.nvim/blob/652dfa792c52f31d873b7937528f87cbeb0c6625/lua/vscode/init.lua#L42