### PR TITLE
feat: add support for glepnir/dashboard-nvim

### DIFF
--- a/lua/vscode/theme.lua
+++ b/lua/vscode/theme.lua
@@ -474,6 +474,13 @@ theme.set_highlights = function(opts)
     hl(0, 'CmpItemAbbrMatch', { fg = isDark and c.vscMediumBlue or c.vscDarkBlue, bg = 'NONE', bold = true })
     hl(0, 'CmpItemAbbrMatchFuzzy', { fg = isDark and c.vscMediumBlue or c.vscDarkBlue, bg = 'NONE', bold = true })
 
+    -- Dashboard
+    hl(0, 'DashboardHeader', { fg = c.vscBlue, bg = 'NONE' })
+    hl(0, 'DashboardCenter', { fg = c.vscYellowOrange, bg = 'NONE' })
+    hl(0, 'DashboardCenterIcon', { fg = c.vscYellowOrange, bg = 'NONE' })
+    hl(0, 'DashboardShortCut', { fg = c.vscPink, bg = 'NONE' })
+    hl(0, 'DashboardFooter', { fg = c.vscBlue, bg = 'NONE', italic = true })
+
     if isDark then
         hl(0, 'NvimTreeFolderIcon', { fg = c.vscBlue, bg = 'NONE' })
         hl(0, 'NvimTreeIndentMarker', { fg = c.vscLineNumber, bg = 'NONE' })


### PR DESCRIPTION
Highlight groups for [glepnir/dashboard-nvim](https://github.com/glepnir/dashboard-nvim) seem to be `cleared` by default: ensure values are set to match colorscheme.

| Dark | Light |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/36192863/178829217-51884d44-5db3-41eb-8ae2-ebb08aa81722.png) | ![image](https://user-images.githubusercontent.com/36192863/178829012-be18b5d4-8d71-4fbe-842e-a5172ee4bbaa.png) |