### PR TITLE
Change vim.g.vscode_transparency check to vim.g.vscode_transparent

### DIFF
--- a/lua/vscode/init.lua
+++ b/lua/vscode/init.lua
@@ -15,7 +15,7 @@ vscode.setup = function(user_opts)
 
     -- backwards compatibility: let users still set settings with global vars
     local global_settings_opts = vim.tbl_extend('force', defaults, {
-        transparent = vim.g.vscode_transparency == 1,
+        transparent = vim.g.vscode_transparent == 1,
         italic_comments = vim.g.vscode_italic_comment == 1,
         disable_nvimtree_bg = vim.g.vscode_disable_nvim_tree_bg == true,
     })


### PR DESCRIPTION
The suggested fix from my comment on #71.

I can also make the backwards compatibility more complete/complex:

1. check `vim.g.transparent == 1`
2. check `vim.g.transparent == true`
3. check `vim.g.transparency == 1`
4. check `vim.g.transparency == true`

Let me know if you want this to be as complete as possible.
