### PR TITLE
feat(theme/light/coc,pmenu): add highlight

### DIFF
--- a/lua/vscode/theme.lua
+++ b/lua/vscode/theme.lua
@@ -555,6 +555,15 @@ theme.set_highlights = function(opts)
         hl(0, 'TelescopeMatching', { fg='orange', bg='NONE', bold=true, nil  })
         hl(0, 'TelescopePromptPrefix', { fg=c.vscFront, bg='NONE' })
 
+        -- COC.nvim
+        hl(0, 'CocFloating', { fg='NONE', bg=c.vscPopupBack })
+        hl(0, 'CocMenuSel', { fg='#FFFFFF', bg='#285EBA' })
+        hl(0, 'CocSearch', { fg='#2A64B9', bg='NONE' })
+
+        -- Pmenu
+        hl(0, 'Pmenu', { fg='NONE', bg=c.vscPopupBack })
+        hl(0, 'PmenuSel', { fg='#FFFFFF', bg='#285EBA' })
+
         -- symbols-outline
         -- white fg and lualine blue bg
         hl(0, 'FocusedSymbol', { fg=c.vscBack, bg='#AF00DB' })


### PR DESCRIPTION
| Aspect | Before | After |  
| -- | -- | -- |  
| COC.nvim menu | ![image](https://user-images.githubusercontent.com/23183656/182816386-cdcac8ec-2f97-4f20-b344-27d00d139a03.png) | ![image](https://user-images.githubusercontent.com/23183656/182816042-5d641915-4cd5-496b-a18f-9807c96bbd52.png)|
| Built-in menu | ![image](https://user-images.githubusercontent.com/23183656/182816589-2c686b97-6601-4baa-a24c-1f72d01cb268.png) | ![image](https://user-images.githubusercontent.com/23183656/182816758-8898c20a-033a-4369-8b1a-d2b9739cd951.png) | 

## Reference (original VS Code Default Light theme)
![image](https://user-images.githubusercontent.com/23183656/182816958-aa4e45a4-4a23-4e3f-8403-a4dbdcf5ab8f.png)
