### PR TITLE
docs: add Dashboard to supported plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ vscode.nvim (formerly `codedark.nvim`) is a Lua port of [vim-code-dark](https://
 
 - [BarBar](https://github.com/romgrk/barbar.nvim)
 - [BufferLine](https://github.com/akinsho/nvim-bufferline.lua)
+- [Dashboard](https://github.com/glepnir/dashboard-nvim)
 - [Git Gutter](https://github.com/airblade/vim-gitgutter)
 - [Git Signs](https://github.com/lewis6991/gitsigns.nvim)
 - [Indent Blankline](https://github.com/lukas-reineke/indent-blankline.nvim)


### PR DESCRIPTION
Forgot to add documentation for supported plugin: f1a3e73779d866fd50629ca98cb46b5be8bc3162