### PR TITLE
fix: set underline for indent-blankline ContextStart

### DIFF
--- a/lua/vscode/theme.lua
+++ b/lua/vscode/theme.lua
@@ -448,7 +448,7 @@ theme.set_highlights = function(opts)
 
     -- IndentBlankLine
     hl(0, 'IndentBlanklineContextChar', { fg = c.vscContextCurrent, bg = 'NONE', nocombine = true })
-    hl(0, 'IndentBlanklineContextStart', { fg = c.vscContextCurrent, bg = 'NONE', nocombine = true })
+    hl(0, 'IndentBlanklineContextStart', { sp = c.vscContextCurrent, bg = 'NONE', nocombine = true, underline = true })
     hl(0, 'IndentBlanklineChar', { fg = c.vscContext, bg = 'NONE', nocombine = true })
     hl(0, 'IndentBlanklineSpaceChar', { fg = c.vscContext, bg = 'NONE', nocombine = true })
     hl(0, 'IndentBlanklineSpaceCharBlankline', { fg = c.vscContext, bg = 'NONE', nocombine = true })


### PR DESCRIPTION
I think that the highlight group `IndentBlanklineCurrentContext` should either be removed in order to use the plugins default settings, or should be changed to use an underline that matches the current context color set by #50.

This PR currently does the latter and preserves `IndentBlanklineCurrentContext` but sets `underline = true` and switches `guifg` with `guisp` for `vscContextCurrent`.

With `indent_blankline.setup({ show_current_context_start = true })`, vscode.nvim sets a foreground color for `IndentBlanlineContextStart`, resulting in treesitter highlights being overridden with `colors.vscContextCurrent`.

![WindowsTerminal_pXJs6kFvuF](https://user-images.githubusercontent.com/36192863/203468922-10b1928a-30db-4138-b697-1096544a0bd5.gif)

Using tokyonight as a comparison: 
`IndentBlanklineCurrentContext` isn't set at all, implying that the default settings from indent-blankline.nvim are used.

![WindowsTerminal_IG5yT7XuOK](https://user-images.githubusercontent.com/36192863/203470555-7d23096c-1209-496e-b9c6-5547733acd7c.gif)