### PR TITLE
chore: remove unneeded printout

### DIFF
--- a/lua/vscode/init.lua
+++ b/lua/vscode/init.lua
@@ -49,7 +49,6 @@ end
 
 vscode.change_style = function(style)
     vim.o.background = style
-    print('Vscode style: ', style)
     vim.cmd([[colorscheme vscode]])
 end
 


### PR DESCRIPTION
When changing styles, printout shouldn't be forced on the user.

I'm bothered by it because I prefer to default this colorscheme with just
```lua
require("vscode").change_style("dark")
```
and that printout pops up every time I start Neovim.

Why do I set colorscheme like this?
I find it natural for colorscheme to set `vim.o.background = "dark"`, rather than the user and that's precisely what `change_style` does for me.