### PR TITLE
refactor: handling config and theme initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ vim.o.background = 'light'
 
 local c = require('vscode.colors').get_colors()
 require('vscode').setup({
+    -- Alternatively set style in setup
+    -- style = 'light'
+
     -- Enable transparent background
     transparent = true,
 
@@ -149,8 +152,8 @@ require("bufferline").setup({
 ## Switching theme
 
 ```
-:lua require('vscode').change_style('light')
-:lua require('vscode').change_style('dark')
+:lua require('vscode').load('light')
+:lua require('vscode').load('dark')
 ```
 
 ## 🍭 Extra folder

--- a/colors/vscode.lua
+++ b/colors/vscode.lua
@@ -1,2 +1,2 @@
 local vscode = require('vscode')
-vscode.setup({})
+vscode.load()

--- a/colors/vscode.lua
+++ b/colors/vscode.lua
@@ -1,0 +1,2 @@
+local vscode = require('vscode')
+vscode.setup({})

--- a/colors/vscode.vim
+++ b/colors/vscode.vim
@@ -1,4 +1,0 @@
-lua << EOF
-local vscode = require("vscode")
-vscode.setup({})
-EOF

--- a/lua/vscode/config.lua
+++ b/lua/vscode/config.lua
@@ -1,0 +1,31 @@
+local config = {}
+
+local defaults = {
+    transparent = false,
+    italic_comments = false,
+    color_overrides = {},
+    group_overrides = {},
+    disable_nvimtree_bg = true,
+}
+
+config.opts = {}
+
+---@param user_opts table
+config.setup = function(user_opts)
+    -- backwards compatibility: let users still set settings with global vars
+    local global_settings_opts = vim.tbl_extend('force', defaults, {
+        transparent = (vim.g.vscode_transparent == true or vim.g.vscode_transparent == 1),
+        italic_comments = (vim.g.vscode_italic_comment == true or vim.g.vscode_italic_comment == 1),
+        disable_nvimtree_bg = (vim.g.vscode_disable_nvim_tree_bg == true or vim.g.vscode_disable_nvim_tree_bg == 1),
+    })
+
+    -- but override global vars settings with setup() settings
+    config.opts = vim.tbl_extend('force', global_settings_opts, user_opts)
+
+    -- setting transparent to true removes the default background
+    if config.opts.transparent then
+        config.opts.color_overrides.vscBack = 'NONE'
+    end
+end
+
+return config

--- a/lua/vscode/init.lua
+++ b/lua/vscode/init.lua
@@ -5,8 +5,12 @@ local vscode = {}
 local config = require('vscode.config')
 local theme = require('vscode.theme')
 
-vscode.setup = function(user_opts)
-    config.setup(user_opts)
+-- Pass setup to config module
+vscode.setup = config.setup
+
+-- Load colorscheme with a given or default style
+---@param style? string
+vscode.load = function()
     vim.cmd('hi clear')
     if vim.fn.exists('syntax_on') then
         vim.cmd('syntax reset')

--- a/lua/vscode/init.lua
+++ b/lua/vscode/init.lua
@@ -2,35 +2,11 @@
 -- Lua port of https://github.com/tomasiser/vim-code-dark
 -- By http://github.com/mofiqul
 local vscode = {}
+local config = require('vscode.config')
 local theme = require('vscode.theme')
 
 vscode.setup = function(user_opts)
-    local defaults = {
-        transparent = false,
-        italic_comments = false,
-        color_overrides = {},
-        group_overrides = {},
-        disable_nvimtree_bg = true,
-    }
-
-    -- backwards compatibility: let users still set settings with global vars
-    local global_settings_opts = vim.tbl_extend('force', defaults, {
-        transparent = (vim.g.vscode_transparent == true
-                       or vim.g.vscode_transparent == 1),
-        italic_comments = (vim.g.vscode_italic_comment == true
-                           or vim.g.vscode_italic_comment == 1),
-        disable_nvimtree_bg = (vim.g.vscode_disable_nvim_tree_bg == true
-                               or vim.g.vscode_disable_nvim_tree_bg == 1),
-    })
-
-    -- but override global vars settings with setup() settings
-    local opts = vim.tbl_extend('force', global_settings_opts, user_opts)
-
-    -- setting transparent to true removes the default background
-    if opts.transparent then
-        opts.color_overrides.vscBack = 'NONE'
-    end
-
+    config.setup(user_opts)
     vim.cmd('hi clear')
     if vim.fn.exists('syntax_on') then
         vim.cmd('syntax reset')
@@ -39,10 +15,10 @@ vscode.setup = function(user_opts)
     vim.o.termguicolors = true
     vim.g.colors_name = 'vscode'
 
-    theme.set_highlights(opts)
+    theme.set_highlights(config.opts)
     theme.link_highlight()
 
-    for group, val in pairs(opts['group_overrides']) do
+    for group, val in pairs(config.opts['group_overrides']) do
         vim.api.nvim_set_hl(0, group, val)
     end
 end

--- a/lua/vscode/init.lua
+++ b/lua/vscode/init.lua
@@ -10,7 +10,7 @@ vscode.setup = config.setup
 
 -- Load colorscheme with a given or default style
 ---@param style? string
-vscode.load = function()
+vscode.load = function(style)
     vim.cmd('hi clear')
     if vim.fn.exists('syntax_on') then
         vim.cmd('syntax reset')
@@ -19,17 +19,14 @@ vscode.load = function()
     vim.o.termguicolors = true
     vim.g.colors_name = 'vscode'
 
+    vim.o.background = style or config.opts.style or vim.o.background
+
     theme.set_highlights(config.opts)
     theme.link_highlight()
 
     for group, val in pairs(config.opts['group_overrides']) do
         vim.api.nvim_set_hl(0, group, val)
     end
-end
-
-vscode.change_style = function(style)
-    vim.o.background = style
-    vim.cmd([[colorscheme vscode]])
 end
 
 return vscode


### PR DESCRIPTION
When loading the plugin from a plugin manager the themes setup function would apply both configuration and the theme itself. This doesn't seem to be the case for many other popular colorschemes where only default/user configuration is applied on setup allowing the user to choose when to enable the colorscheme via `colorscheme {theme}` or `require('theme').load(style)`.

While applying these changes there were a few other things I modified.

- Allow style to be set from setup table and fallback to `vim.o.background`.
- Replace functionally for `vscode.change_style` to `vscode.load`.
  Basically simplifies the plugins api.

- Rename colorscheme entrypoint file `colors/vscode.vim` to lua.
  This doesn't change anything but appeals to be dislike of vimscript.
  Much older versions of neovim might not support directly loading lua runtime files.