### PR TITLE
fix: error when color_overrides not set

### DIFF
--- a/lua/vscode/init.lua
+++ b/lua/vscode/init.lua
@@ -24,8 +24,10 @@ vscode.load = function(style)
     theme.set_highlights(config.opts)
     theme.link_highlight()
 
-    for group, val in pairs(config.opts['group_overrides']) do
-        vim.api.nvim_set_hl(0, group, val)
+    if config.opts.group_overrides then
+      for group, val in pairs(config.opts['group_overrides']) do
+          vim.api.nvim_set_hl(0, group, val)
+      end
     end
 end
 

--- a/lua/vscode/theme.lua
+++ b/lua/vscode/theme.lua
@@ -3,7 +3,9 @@ local theme = {}
 
 theme.set_highlights = function(opts)
     local c = require('vscode.colors').get_colors()
-    c = vim.tbl_extend('force', c, opts['color_overrides'])
+    if opts.color_overrides then
+      c = vim.tbl_extend('force', c, opts['color_overrides'])
+    end
     local isDark = vim.o.background == 'dark'
 
     hl(0, 'Normal', { fg = c.vscFront, bg = c.vscBack })


### PR DESCRIPTION
fix a error throws when color_overrides not set in user custom config.
the error msg I got as follows:
`
Error detected while processing /home/hewenjin/project/my/config/nvim/plugin/options.vim[45]../home/hewenjin/.local/share/nvim/site/pack/packer/start/vscode.nvim/colors/vscode.lua:
E5113: Error while calling lua chunk: vim/shared.lua:0: after the second argument: expected table, got nil
stack traceback:
        [C]: in function 'error'
        vim/shared.lua: in function 'validate'
        vim/shared.lua: in function 'tbl_extend'
        .../site/pack/packer/start/vscode.nvim/lua/vscode/theme.lua:6: in function 'set_highlights'
        ...m/site/pack/packer/start/vscode.nvim/lua/vscode/init.lua:24: in function 'load'
        ...vim/site/pack/packer/start/vscode.nvim/colors/vscode.lua:2: in main chunk
`