### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ require('vscode').setup({
         Cursor = { fg=c.vscDarkBlue, bg=c.vscLightGreen, bold=true },
     }
 })
+require('vscode').load()
 ```
 
 


### PR DESCRIPTION
Add `require('vscode').load()` to Usage section because an explicit call to `.load()` is now necessary as of #118