### PR TITLE
feat: highlight coc symbol under cursor

### DIFF
--- a/lua/vscode/theme.lua
+++ b/lua/vscode/theme.lua
@@ -481,6 +481,11 @@ theme.set_highlights = function(opts)
     hl(0, 'LspReferenceRead', { fg = 'NONE', bg = isDark and c.vscPopupHighlightGray or c.vscPopupHighlightLightBlue })
     hl(0, 'LspReferenceWrite', { fg = 'NONE', bg = isDark and c.vscPopupHighlightGray or c.vscPopupHighlightLightBlue })
 
+    -- COC.nvim
+    hl(0, 'CocHighlightText', { fg = 'NONE', bg = isDark and c.vscPopupHighlightGray or c.vscPopupHighlightLightBlue })
+    hl(0, 'CocHighlightRead', { fg = 'NONE', bg = isDark and c.vscPopupHighlightGray or c.vscPopupHighlightLightBlue })
+    hl(0, 'CocHighlightWrite', { fg = 'NONE', bg = isDark and c.vscPopupHighlightGray or c.vscPopupHighlightLightBlue })
+
     -- Nvim compe
     hl(0, 'CmpItemKindVariable', { fg = c.vscLightBlue, bg = 'NONE' })
     hl(0, 'CmpItemKindInterface', { fg = c.vscLightBlue, bg = 'NONE' })


### PR DESCRIPTION
This adds the [coc.nvim](https://github.com/neoclide/coc.nvim) highlight groups which are used for highlighting the symbol at the current cursor position.

The colors are the same as LSP reference highlight colors: [dark](https://github.com/Mofiqul/vscode.nvim/pull/23), [light](https://github.com/Mofiqul/vscode.nvim/pull/47).

**Dark:**
![image](https://user-images.githubusercontent.com/40922273/226140792-85127272-a3b7-4bb9-947b-85aec02ecf3d.png)

**Light:**
![image](https://user-images.githubusercontent.com/40922273/226140899-8b54380e-eb02-4424-b2a7-20e06d14cfba.png)
