### PR TITLE
fix: global opts due to config not being initialized

### DIFF
--- a/lua/vscode/config.lua
+++ b/lua/vscode/config.lua
@@ -10,7 +10,7 @@ local defaults = {
 
 config.opts = {}
 
----@param user_opts table
+---@param user_opts? table
 config.setup = function(user_opts)
     -- backwards compatibility: let users still set settings with global vars
     local global_settings_opts = vim.tbl_extend('force', defaults, {
@@ -20,12 +20,15 @@ config.setup = function(user_opts)
     })
 
     -- but override global vars settings with setup() settings
-    config.opts = vim.tbl_extend('force', global_settings_opts, user_opts)
+    config.opts = vim.tbl_extend('force', global_settings_opts, user_opts or {})
 
     -- setting transparent to true removes the default background
     if config.opts.transparent then
         config.opts.color_overrides.vscBack = 'NONE'
     end
 end
+
+-- initialize config
+config.setup()
 
 return config

--- a/lua/vscode/init.lua
+++ b/lua/vscode/init.lua
@@ -25,9 +25,9 @@ vscode.load = function(style)
     theme.link_highlight()
 
     if config.opts.group_overrides then
-      for group, val in pairs(config.opts['group_overrides']) do
-          vim.api.nvim_set_hl(0, group, val)
-      end
+        for group, val in pairs(config.opts['group_overrides']) do
+            vim.api.nvim_set_hl(0, group, val)
+        end
     end
 end
 

--- a/lua/vscode/theme.lua
+++ b/lua/vscode/theme.lua
@@ -4,7 +4,7 @@ local theme = {}
 theme.set_highlights = function(opts)
     local c = require('vscode.colors').get_colors()
     if opts.color_overrides then
-      c = vim.tbl_extend('force', c, opts['color_overrides'])
+        c = vim.tbl_extend('force', c, opts['color_overrides'])
     end
     local isDark = vim.o.background == 'dark'
 
@@ -429,7 +429,11 @@ theme.set_highlights = function(opts)
     hl(0, 'NvimTreeCursorLine', { fg = 'NONE', bg = opts.disable_nvimtree_bg and c.vscCursorDarkDark or c.vscLeftMid })
     hl(0, 'NvimTreeVertSplit', { fg = opts.disable_nvimtree_bg and c.vscSplitDark or c.vscBack, bg = c.vscBack })
     hl(0, 'NvimTreeEndOfBuffer', { fg = opts.disable_nvimtree_bg and c.vscCursorDarkDark or c.vscLeftDark })
-    hl(0, 'NvimTreeOpenedFolderName', { fg = 'NONE', bg = opts.disable_nvimtree_bg and c.vscCursorDarkDark or c.vscLeftDark })
+    hl(
+        0,
+        'NvimTreeOpenedFolderName',
+        { fg = 'NONE', bg = opts.disable_nvimtree_bg and c.vscCursorDarkDark or c.vscLeftDark }
+    )
     hl(0, 'NvimTreeGitRenamed', { fg = c.vscGitRenamed, bg = 'NONE' })
     hl(0, 'NvimTreeGitIgnored', { fg = c.vscGitIgnored, bg = 'NONE' })
     hl(0, 'NvimTreeGitDeleted', { fg = c.vscGitDeleted, bg = 'NONE' })
@@ -567,28 +571,28 @@ theme.set_highlights = function(opts)
         hl(0, 'LspSagaRenameBorder', { fg = c.vscTabOther, bg = 'NONE' })
         hl(0, 'LspSagaLspFinderBorder', { fg = c.vscTabOther, bg = 'NONE' })
 
-        hl(0, 'TelescopePromptBorder', { fg=c.vscTabOther, bg='NONE' })
-        hl(0, 'TelescopeResultsBorder', { fg=c.vscTabOther, bg='NONE' })
-        hl(0, 'TelescopePreviewBorder', { fg=c.vscTabOther, bg='NONE' })
-        hl(0, 'TelescopeNormal', { fg=c.vscFront, bg='NONE' })
-        hl(0, 'TelescopeSelection', { fg='#FFFFFF', bg=c.vscPopupHighlightBlue })
-        hl(0, 'TelescopeMultiSelection', { fg=c.vscBack, bg=c.vscPopupHighlightBlue })
-        hl(0, 'TelescopeMatching', { fg='orange', bg='NONE', bold=true, nil  })
-        hl(0, 'TelescopePromptPrefix', { fg=c.vscFront, bg='NONE' })
+        hl(0, 'TelescopePromptBorder', { fg = c.vscTabOther, bg = 'NONE' })
+        hl(0, 'TelescopeResultsBorder', { fg = c.vscTabOther, bg = 'NONE' })
+        hl(0, 'TelescopePreviewBorder', { fg = c.vscTabOther, bg = 'NONE' })
+        hl(0, 'TelescopeNormal', { fg = c.vscFront, bg = 'NONE' })
+        hl(0, 'TelescopeSelection', { fg = '#FFFFFF', bg = c.vscPopupHighlightBlue })
+        hl(0, 'TelescopeMultiSelection', { fg = c.vscBack, bg = c.vscPopupHighlightBlue })
+        hl(0, 'TelescopeMatching', { fg = 'orange', bg = 'NONE', bold = true, nil })
+        hl(0, 'TelescopePromptPrefix', { fg = c.vscFront, bg = 'NONE' })
 
         -- COC.nvim
-        hl(0, 'CocFloating', { fg='NONE', bg=c.vscPopupBack })
-        hl(0, 'CocMenuSel', { fg='#FFFFFF', bg='#285EBA' })
-        hl(0, 'CocSearch', { fg='#2A64B9', bg='NONE' })
+        hl(0, 'CocFloating', { fg = 'NONE', bg = c.vscPopupBack })
+        hl(0, 'CocMenuSel', { fg = '#FFFFFF', bg = '#285EBA' })
+        hl(0, 'CocSearch', { fg = '#2A64B9', bg = 'NONE' })
 
         -- Pmenu
-        hl(0, 'Pmenu', { fg='NONE', bg=c.vscPopupBack })
-        hl(0, 'PmenuSel', { fg='#FFFFFF', bg='#285EBA' })
+        hl(0, 'Pmenu', { fg = 'NONE', bg = c.vscPopupBack })
+        hl(0, 'PmenuSel', { fg = '#FFFFFF', bg = '#285EBA' })
 
         -- symbols-outline
         -- white fg and lualine blue bg
-        hl(0, 'FocusedSymbol', { fg=c.vscBack, bg='#AF00DB' })
-        hl(0, 'SymbolsOutlineConnector', { fg=c.vscTabOther, bg='NONE' })
+        hl(0, 'FocusedSymbol', { fg = c.vscBack, bg = '#AF00DB' })
+        hl(0, 'SymbolsOutlineConnector', { fg = c.vscTabOther, bg = 'NONE' })
     end
 end
 


### PR DESCRIPTION
Fixes #122

It seems that the config module: `config.setup` was not being initialized without explicitly calling the setup function, which broke vimscript config that is applied via global variables.