### PR TITLE
docs: update README - bufferline close command

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ require('lualine').setup({
 require("bufferline").setup({
     options = {
         buffer_close_icon = "",
-        close_command = "Bdelete %d",
+        close_command = "bdelete %d",
         close_icon = "",
         indicator = {
           style = "icon",
@@ -100,7 +100,7 @@ require("bufferline").setup({
         left_trunc_marker = "",
         modified_icon = "●",
         offsets = { { filetype = "NvimTree", text = "EXPLORER", text_align = "center" } },
-        right_mouse_command = "Bdelete! %d",
+        right_mouse_command = "bdelete! %d",
         right_trunc_marker = "",
         show_close_icon = false,
         show_tab_indicators = true,


### PR DESCRIPTION
According to bufferline doc: https://github.com/akinsho/bufferline.nvim/blob/01b20685000e704214e58d5d8cd0851c1657efee/doc/bufferline.txt#L71 The close command should be lowercase `bdelete %d`

Getting error when using uppercase:
![Screenshot 2023-04-01 at 7 15 38 AM](https://user-images.githubusercontent.com/55214510/229295017-ec4aef80-1869-4c05-89d9-4ebdcd721340.png)
