### PR TITLE
Added colorscheme for foot terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ require("bufferline").setup({
 - [Windows Terminal](https://github.com/microsoft/terminal) color scheme
 - [Xresources](https://wiki.debian.org/Xresources) color scheme
 - [zathura](https://pwmt.org/projects/zathura/) color scheme
+- [Foot](https://codeberg.org/dnkl/foot) color scheme
 
 ## Something is broken but I know how to fix it!
 

--- a/extra/foot/vscode-dark
+++ b/extra/foot/vscode-dark
@@ -1,0 +1,24 @@
+[colors]
+alpha=1.00
+foreground=d4d4d4
+background=1e1e1e
+
+## Normal/regular colors (color palette 0-7)
+ regular0=1e1e1e  # black
+ regular1=f44747  # red
+ regular2=607b4e  # green
+ regular3=dcdcaa  # yellow
+ regular4=569cd6  # blue
+ regular5=c678dd  # magenta
+ regular6=56b6c2  # cyan
+ regular7=d4d4d4  # white
+
+## Bright colors (color palette 8-15)
+ bright0=808080   # bright black
+ bright1=f44747   # bright red
+ bright2=607b4e   # bright green
+ bright3=dcdcaa   # bright yellow
+ bright4=569cd6   # bright blue
+ bright5=c678dd   # bright magenta
+ bright6=56b6c2   # bright cyan
+ bright7=d4d4d4   # bright white

--- a/extra/foot/vscode-light
+++ b/extra/foot/vscode-light
@@ -1,0 +1,24 @@
+[colors]
+alpha=1.00
+foreground=000000
+background=ffffff
+
+## Normal/regular colors (color palette 0-7)
+ regular0=000000  # black
+ regular1=c7230f  # red
+ regular2=008000  # green
+ regular3=795e25  # yellow
+ regular4=007acc  # blue
+ regular5=af00db  # magenta
+ regular6=56b6c2  # cyan
+ regular7=000000  # white
+
+## Bright colors (color palette 8-15)
+ bright0=808080   # bright black
+ bright1=c7230f   # bright red
+ bright2=008000   # bright green
+ bright3=795e25   # bright yellow
+ bright4=007acc   # bright blue
+ bright5=af00db   # bright magenta
+ bright6=56b6c2   # bright cyan
+ bright7=000000   # bright white


### PR DESCRIPTION
I've added both vscode-dark and vscode-light colorschemes for [foot terminal](https://codeberg.org/dnkl/foot) and also updated the readme to reflect the same. 