### PR TITLE
fix: Lualine does not respect transparency (#89)

### DIFF
--- a/lua/lualine/themes/vscode.lua
+++ b/lua/lualine/themes/vscode.lua
@@ -1,5 +1,6 @@
 -- Copyright (c) 2020-2021 Mofiqul Islam
 -- MIT license, see LICENSE for more details.
+local config = require('vscode.config')
 local vscode = {}
 local colors = {}
 
@@ -29,43 +30,43 @@ end
 
 vscode.normal = {
     a = { fg = vim.o.background == 'dark' and colors.fg or colors.bg, bg = colors.blue, gui = 'bold' },
-    b = { fg = colors.blue, bg = colors.bg2 },
-    c = { fg = colors.fg, bg = colors.bg },
+    b = { fg = colors.blue, bg = config.opts.transparent and 'NONE' or colors.bg2 },
+    c = { fg = colors.fg, bg = config.opts.transparent and 'NONE' or colors.bg },
 }
 
 vscode.visual = {
     a = { fg = colors.bg, bg = colors.yellow, gui = 'bold' },
-    b = { fg = colors.yellow, bg = colors.bg2 },
+    b = { fg = colors.yellow, bg = config.opts.transparent and 'NONE' or colors.bg },
 }
 
 vscode.inactive = {
     a = { fg = colors.fg, bg = colors.bg, gui = 'bold' },
-    b = { fg = colors.inactive, bg = colors.bg },
-    c = { fg = colors.inactive, bg = colors.bg },
+    b = { fg = colors.inactive, bg = config.opts.transparent and 'NONE' or colors.bg },
+    c = { fg = colors.inactive, bg = config.opts.transparent and 'NONE' or colors.bg },
 }
 
 vscode.replace = {
     a = { fg = vim.o.background == 'dark' and colors.bg or colors.fg, bg = colors.red, gui = 'bold' },
-    b = { fg = colors.red, bg = colors.bg2 },
-    c = { fg = colors.fg, bg = colors.bg },
+    b = { fg = colors.red, bg = config.opts.transparent and 'NONE' or colors.bg2 },
+    c = { fg = colors.fg, bg = config.opts.transparent and 'NONE' or colors.bg },
 }
 
 vscode.insert = {
     a = { fg = vim.o.background == 'dark' and colors.bg or colors.fg, bg = colors.green, gui = 'bold' },
-    b = { fg = colors.green, bg = colors.bg2 },
-    c = { fg = colors.fg, bg = colors.bg },
+    b = { fg = colors.green, bg = config.opts.transparent and 'NONE' or colors.bg2 },
+    c = { fg = colors.fg, bg = config.opts.transparent and 'NONE' or colors.bg },
 }
 
 vscode.terminal = {
     a = { fg = vim.o.background == 'dark' and colors.bg or colors.fg, bg = colors.green, gui = 'bold' },
-    b = { fg = colors.fg, bg = colors.bg2 },
-    c = { fg = colors.fg, bg = colors.bg },
+    b = { fg = colors.fg, bg = config.opts.transparent and 'NONE' or colors.bg2 },
+    c = { fg = colors.fg, bg = config.opts.transparent and 'NONE' or colors.bg },
 }
 
 vscode.command = {
     a = { fg = vim.o.background == 'dark' and colors.bg or colors.fg, bg = colors.pink, gui = 'bold' },
-    b = { fg = colors.pink, bg = colors.bg2 },
-    c = { fg = colors.fg, bg = colors.bg },
+    b = { fg = colors.pink, bg = config.opts.transparent and 'NONE' or colors.bg2 },
+    c = { fg = colors.fg, bg = config.opts.transparent and 'NONE' or colors.bg },
 }
 
 return vscode


### PR DESCRIPTION
This fixes #89 where the transparency is not respected in lualine.

Rather than setting `colors.bg and colors.bg2` to `NONE` I've used a ternary condition to set the color accordingly. This is because overriding `colors.bg and colors.bg2` to `NONE` initially will also set the foreground colors of modes to be `NONE` as well wherever they are set to `colors.bg or colors.bg2` which makes the text unreadable. 

I've tested this version and the colors look good and readable to me in both light and dark modes. Please mention if any changes are required. Thank you.

![image](https://user-images.githubusercontent.com/84301852/230789090-47892a45-279e-4140-85c0-05acbffb1a13.png)

![2023-04-09T23:34:32,254741085+05:30](https://user-images.githubusercontent.com/84301852/230789107-4574aee8-f089-4cd5-bab6-1626ab767c14.png)
