### PR TITLE
fix: Bufferline background not transparent

### DIFF
--- a/lua/vscode/theme.lua
+++ b/lua/vscode/theme.lua
@@ -39,7 +39,7 @@ theme.set_highlights = function(opts)
     hl(0, 'Search', { fg = c.vscNone, bg = c.vscSearch })
     hl(0, 'SpecialKey', { fg = c.vscBlue, bg = c.vscNone })
     hl(0, 'StatusLine', { fg = c.vscFront, bg = c.vscLeftMid })
-    hl(0, 'StatusLineNC', { fg = c.vscFront, bg = c.vscLeftDark })
+    hl(0, 'StatusLineNC', { fg = c.vscFront, bg = opts.transparent and c.vscBack or c.vscLeftDark })
     hl(0, 'TabLine', { fg = c.vscFront, bg = c.vscTabOther })
     hl(0, 'TabLineFill', { fg = c.vscFront, bg = c.vscTabOutside })
     hl(0, 'TabLineSel', { fg = c.vscFront, bg = c.vscTabCurrent })
@@ -445,7 +445,7 @@ theme.set_highlights = function(opts)
 
     -- Bufferline
     hl(0, 'BufferLineIndicatorSelected', { fg = c.vscLeftDark, bg = 'NONE' })
-    hl(0, 'BufferLineFill', { fg = 'NONE', bg = c.vscLeftDark })
+    hl(0, 'BufferLineFill', { fg = 'NONE', bg = opts.transparent and c.vscBack or c.vscLeftDark })
 
     -- BarBar
     hl(0, 'BufferCurrent', { fg = c.vscFront, bg = c.vscTabCurrent })


### PR DESCRIPTION
This fixes the weird background fill in Bufferline when transparency is set. In transparent mode Bufferline with it's background transparent makes more sense than having a strong grey bar.

# Before
![2023-04-11T15:53:32,354285295+05:30](https://user-images.githubusercontent.com/84301852/231143138-86ba2da2-85ba-4b1e-8bf6-ee1dd91feb3d.png)

# After
![2023-04-11T15:53:12,112794029+05:30](https://user-images.githubusercontent.com/84301852/231143308-0e7bc851-53c4-4969-9f1b-944d39ad02ee.png)

