### PR TITLE
feat: support highlight groups of Treesitter's diff parser

### DIFF
--- a/lua/vscode/theme.lua
+++ b/lua/vscode/theme.lua
@@ -153,6 +153,9 @@ theme.set_highlights = function(opts)
     hl(0, '@text.warning', { fg = c.vscYellowOrange, bg = 'NONE', bold = true })
     hl(0, '@text.danger', { fg = c.vscRed, bg = 'NONE', bold = true })
 
+    hl(0, '@text.diff.add', { link = 'DiffAdd' })
+    hl(0, '@text.diff.delete', { link = 'DiffDelete' })
+
     -- LSP semantic tokens
     hl(0, '@class', { link = '@type' })
     hl(0, '@struct', { link = '@type' })


### PR DESCRIPTION
I noticed that the diffs are not highlighted in [vim-gitgutter](https://github.com/airblade/vim-gitgutter)'s preview window:
![image](https://user-images.githubusercontent.com/40663923/232031767-164d853e-f047-4366-b6e8-c48bf1e3d8f8.png)

This preview window is parsed by the [relatively recent Treesitter's diff parser](https://github.com/nvim-treesitter/nvim-treesitter/pull/3684), which adds two new highlight groups.

To fix the issue, this PR links the new highlight groups to `DiffAdd` and `DiffDelete`:
![image](https://user-images.githubusercontent.com/40663923/232031955-1d2d1db2-f4c5-4b04-af3f-ceffb12029ae.png)