### PR TITLE
fix: make `get_colors` return wrt to `color_overrides`

### DIFF
--- a/lua/vscode/colors.lua
+++ b/lua/vscode/colors.lua
@@ -150,6 +150,12 @@ colors.get_colors = function()
     mycolors.vscUiOrange = '#f28b25'
     mycolors.vscPopupHighlightLightBlue = '#d7eafe'
 
+    -- Extend the colors with overrides passed by `color_overrides`
+    local config = require('vscode.config')
+    if config.opts.color_overrides then
+        mycolors = vim.tbl_extend('force', mycolors, config.opts.color_overrides)
+    end
+
     return mycolors
 end
 

--- a/lua/vscode/theme.lua
+++ b/lua/vscode/theme.lua
@@ -3,9 +3,6 @@ local theme = {}
 
 theme.set_highlights = function(opts)
     local c = require('vscode.colors').get_colors()
-    if opts.color_overrides then
-        c = vim.tbl_extend('force', c, opts['color_overrides'])
-    end
     local isDark = vim.o.background == 'dark'
 
     hl(0, 'Normal', { fg = c.vscFront, bg = c.vscBack })


### PR DESCRIPTION
### The issue

As a user of the theme, I want `color_overrides`, which I have passed during the setup, to have effect on `get_colors` elsewhere. Currently, they only have effect during the initialization of the theme.

### The fix

Add deep table merge into `get_colors`.

### Tests

Tested locally by importing colors in different other places of my setup.