### PR TITLE
Show current line when debugging

### DIFF
--- a/lua/vscode/theme.lua
+++ b/lua/vscode/theme.lua
@@ -582,6 +582,9 @@ theme.set_highlights = function(opts)
         hl(0, 'TelescopeMatching', { fg = c.vscMediumBlue, bg = 'NONE', bold = true })
         hl(0, 'TelescopePromptPrefix', { fg = c.vscFront, bg = 'NONE' })
 
+        -- Debugging
+        hl(0, 'debugPC', { bg = '#4C4C19' })
+
         -- symbols-outline
         -- white fg and lualine blue bg
         hl(0, 'FocusedSymbol', { fg = '#ffffff', bg = c.vscUiBlue })
@@ -617,6 +620,9 @@ theme.set_highlights = function(opts)
         hl(0, 'TelescopeMultiSelection', { fg = c.vscBack, bg = c.vscPopupHighlightBlue })
         hl(0, 'TelescopeMatching', { fg = 'orange', bg = 'NONE', bold = true, nil })
         hl(0, 'TelescopePromptPrefix', { fg = c.vscFront, bg = 'NONE' })
+
+        -- Debugging
+        hl(0, 'debugPC', { bg = '#FFFFBA' })
 
         -- COC.nvim
         hl(0, 'CocFloating', { fg = 'NONE', bg = c.vscPopupBack })


### PR DESCRIPTION
When debugging with nvim-dap, it uses the [debugPC](https://github.com/mfussenegger/nvim-dap/blob/9adbfdca13afbe646d09a8d7a86d5d031fb9c5a5/lua/dap.lua#L254) highlight to emphasize which line the debugger is at.

before (nvim):

![before](https://github.com/Mofiqul/vscode.nvim/assets/29818440/ee480dfe-f49e-41cf-8bde-e25df78c51f2)


after (nvim):

![after](https://github.com/Mofiqul/vscode.nvim/assets/29818440/c4a65a9d-a434-4a8c-ab18-edb6aa681056)

dark+ (vscode):

![vscode](https://github.com/Mofiqul/vscode.nvim/assets/29818440/efb80ce5-bd0c-4839-bdaf-6f8784280bf6)
