### PR TITLE
i3wm and zathura theme changes

### DIFF
--- a/extra/i3/vscode-dark
+++ b/extra/i3/vscode-dark
@@ -33,10 +33,10 @@ bar {
     background         $background
     statusline         $color8
     separator          $color8
-    focused_workspace  $color6  $color6  $color0
-    active_workspace   $color15 $color15 $color0
-    inactive_workspace $color0  $color0  $color15
-    urgent_workspace   $color3  $color3  $color0
-    binding_mode       $color6  $color6  $color0
+    focused_workspace  $color6 $color6 $color0
+    active_workspace   $color8 $color8 $color0
+    inactive_workspace $color0 $color0 $color8
+    urgent_workspace   $color3 $color3 $color0
+    binding_mode       $color5 $color5 $color0
   }
 }

--- a/extra/zathura/vscode-dark
+++ b/extra/zathura/vscode-dark
@@ -4,7 +4,7 @@ set default-bg                  "#1e1e1e"
 set default-fg                  "#d4d4d4"
 
 set statusbar-bg                "#1e1e1e"
-set statusbar-fg                "#808080"
+set statusbar-fg                "#d4d4d4"
 
 set inputbar-bg                 "#1e1e1e"
 set inputbar-fg                 "#d4d4d4"


### PR DESCRIPTION
I have made a couple visual tweaks in the i3wm and zathura dark theme extras since I submitted them:

- Made the zathura statusbar text use the white instead of the darker gray color - more legible and matching nsxiv image viewer and lf file manager status bar colors for example.
  ![1706750820](https://github.com/Mofiqul/vscode.nvim/assets/52537705/2be4cc11-09b7-4838-992a-c7ad9feda1a8)
- Made i3wm status bar to have more visible unfocused display active workspace number indicator - full bg. gray highlight. And a more visible i3 mode indicator - purple instead of cyan, which previously was (too) same as the active workspace. Example with bar on 3 displays:
  ![1706751924](https://github.com/Mofiqul/vscode.nvim/assets/52537705/8ecd6957-5230-4695-ace1-b0e9466dcc12)

