### PR TITLE
fix: Improve barbar support by changing tabline background color

### DIFF
--- a/lua/vscode/theme.lua
+++ b/lua/vscode/theme.lua
@@ -491,6 +491,8 @@ theme.set_highlights = function(opts)
     hl(0, 'BufferInactiveMod', { fg = c.vscYellowOrange, bg = c.vscTabOther })
     hl(0, 'BufferInactiveSign', { fg = c.vscGray, bg = c.vscTabOther })
     hl(0, 'BufferInactiveTarget', { fg = c.vscRed, bg = c.vscTabOther })
+    hl(0, 'BufferTabpage', { fg = c.vscFront, bg = c.vscTabOther })
+    hl(0, 'BufferTabpageFill', { fg = c.vscFront, bg = c.vscTabOther })
     hl(0, 'BufferTabpages', { fg = c.vscFront, bg = c.vscTabOther })
     hl(0, 'BufferTabpagesFill', { fg = c.vscFront, bg = c.vscTabOther })
 


### PR DESCRIPTION
This PR aims to improve support for [barbar.nvim](https://github.com/romgrk/barbar.nvim). There has always been this little spill after the last tab which bothered me. This PR fixes that by changing the background color of the tabline to match it.

| Before | After |
| --- | --- |
| ![Screenshot from 2024-02-23 21-40-24](https://github.com/Mofiqul/vscode.nvim/assets/16181067/8b19ce23-d592-4f10-8b11-1d122553039b)  |![Screenshot from 2024-02-23 21-41-52](https://github.com/Mofiqul/vscode.nvim/assets/16181067/d3fca749-1447-4033-9935-948577e50ec3) |

Full Neovim looks like this:

![Screenshot from 2024-02-23 21-42-03](https://github.com/Mofiqul/vscode.nvim/assets/16181067/cbd4aa95-5e6e-40ae-b5b1-894c1de0de8c)

On light mode:

![image](https://github.com/Mofiqul/vscode.nvim/assets/16181067/0d44b32f-0ef4-432e-8e8a-d263f4e3586e)
