### PR TITLE
Add some highlights used by Neovim 0.10

### DIFF
--- a/lua/vscode/theme.lua
+++ b/lua/vscode/theme.lua
@@ -86,6 +86,9 @@ theme.set_highlights = function(opts)
     hl(0, 'SpellRare', { fg = c.vscRed, bg = c.vscBack, undercurl = true, sp = c.vscRed })
     hl(0, 'SpellLocal', { fg = c.vscRed, bg = c.vscBack, undercurl = true, sp = c.vscRed })
     hl(0, 'Whitespace', { fg = isDark and c.vscLineNumber or c.vscTabOther })
+    hl(0, 'NormalFloat', { bg = c.vscPopupBack })
+    hl(0, 'WinBar', { fg = c.vscFront, bg = c.vscBack, bold = true })
+    hl(0, 'WinBarNc', { fg = c.vscFront, bg = c.vscBack })
 
     -- Treesitter
     hl(0, '@error', { fg = c.vscRed, bg = 'NONE' }) -- Legacy


### PR DESCRIPTION
Upgrading to 0.10 for a bit showed me that `vscode.nvim` is missing a couple of highlights.

### Before

(notice the [dropbar.nvim](https://github.com/Bekaboo/dropbar.nvim) colored black because it's missing `WinBar` and `WinBarNC`, and the floating popup colored black because it's missing `NormalFloat`)

![Screenshot from 2024-02-26 22-12-56](https://github.com/Mofiqul/vscode.nvim/assets/16181067/16de4503-4f6e-4ae6-b425-8cff2eb6c24d)

### After

![Screenshot from 2024-02-26 22-37-19](https://github.com/Mofiqul/vscode.nvim/assets/16181067/bd1ae011-aa0f-4024-b883-286c4e17e7ce)

I'm certain there are more to come, but this is what I've found for now.