### PR TITLE
feat(extra): .Xresources add nsxiv window highlights

### DIFF
--- a/extra/Xresources/vscode-dark
+++ b/extra/Xresources/vscode-dark
@@ -20,3 +20,6 @@
 *.color13: #c678dd
 *.color14: #56b6c2
 *.color15: #d4d4d4
+
+Nsxiv.window.foreground: #608b4e
+Nsxiv.mark.foreground: #f44747

--- a/extra/Xresources/vscode-light
+++ b/extra/Xresources/vscode-light
@@ -20,3 +20,6 @@
 *.color13: #af00db
 *.color14: #56b6c2
 *.color15: #000000
+
+Nsxiv.window.foreground: #008000
+Nsxiv.mark.foreground: #c72e0f


### PR DESCRIPTION
The nsxiv image viewer appearance can be configured through .Xresources. The extras change sets the more noticeable green and red colors for the selected file and the marked file indicator in the image thumbnails view.

![1709921817](https://github.com/Mofiqul/vscode.nvim/assets/52537705/40f5ff5e-1250-443b-b818-37e98b5dbd9a)
