### PR TITLE
fix: on theme.lua still use global colors instead of c

### DIFF
--- a/lua/vscode/theme.lua
+++ b/lua/vscode/theme.lua
@@ -720,7 +720,7 @@ theme.set_highlights = function(opts)
         hl(0, 'PmenuSel', { fg = '#FFFFFF', bg = '#285EBA' })
 
         -- Copilot
-        hl(0, 'CopilotSuggestion', { fg = colors.vscGray, bg = 'NONE' })
+        hl(0, 'CopilotSuggestion', { fg = c.vscGray, bg = 'NONE' })
 
         -- symbols-outline
         -- white fg and lualine blue bg


### PR DESCRIPTION
this is a one liner because on the top of the function, you declared as `c` not `colors`