### PR TITLE
Fix devicon color issue by loading theme with vim.cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,10 @@ require('vscode').setup({
         Cursor = { fg=c.vscDarkBlue, bg=c.vscLightGreen, bold=true },
     }
 })
-require('vscode').load()
+-- require('vscode').load()
+
+-- load the theme without affecting devicon colors.
+vim.cmd.colorscheme "vscode"
 ```
 
 


### PR DESCRIPTION
I noticed that when the project "vscode theme" loads using `require('vscode').load()`, it affects the colors of devicons (there's a chance that the icons fail to color every time it's opened). I'm not sure why this issue occurs, but I found that using `vim.cmd.colorscheme "vscode"` to load doesn't encounter the problem. Although not everyone uses devicon, I think it's worth mentioning in the README to alert users who use both devicon and the vscode theme.