### PR TITLE
correctly highlight JSX/TSX components

### DIFF
--- a/after/queries/jsx/highlights.scm
+++ b/after/queries/jsx/highlights.scm
@@ -1,0 +1,39 @@
+;; extends
+(jsx_opening_element
+  ((identifier) @type
+    (#lua-match? @type "[A-Z]")))
+
+(jsx_closing_element
+  ((identifier) @type
+    (#lua-match? @type "[A-Z]")))
+
+(jsx_opening_element
+  ((identifier) @type
+    (#lua-match? @type "%-")))
+
+(jsx_closing_element
+  ((identifier) @type
+    (#lua-match? @type "%-")))
+
+(jsx_opening_element
+  (member_expression
+    (identifier) @type
+    (property_identifier) @type))
+
+(jsx_closing_element
+  (member_expression
+    (identifier) @type
+    (property_identifier) @type))
+
+(jsx_self_closing_element
+  ((identifier) @type
+    (#lua-match? @type "[A-Z]")))
+
+(jsx_self_closing_element
+  ((identifier) @type
+    (#lua-match? @type "%-")))
+
+(jsx_self_closing_element
+  (member_expression
+    (identifier) @type
+    (property_identifier) @type))


### PR DESCRIPTION
Unfortunately, this required creating a Treesitter query as I couldn't find an easy way of having `@type` overwrite `@tag`, and even if I did, it wouldn't be accurate anyway

the query is partially copied from the nvim-treesitter repository with a few differences

- in relevant queries, `@tag` has been replaced with `@type` to be consistent with VSCodes colouration 
- `(#lua-match? "^[A-Z]")` has been replaced with `(#lua-match? "[A-Z]")` as VScode will highlight a JSX tag as a type if a capital letter is present anywhere within the tag name, not just at the beginning
- if a tag has `-` in its name, it will be highlighted as a `@type` like VSCode (this is what the `(#lua-match? "%-")` queries are for)

resolves part of #189 