### PR TITLE
typescript: highlight type keyword in import statements correctly

### DIFF
--- a/after/queries/typescript/highlights.scm
+++ b/after/queries/typescript/highlights.scm
@@ -10,3 +10,5 @@
 [
   "break"
 ] @keyword.conditional
+
+(import_statement "type" @keyword.import)


### PR DESCRIPTION
TLDR makes the type keyword when in an import statement (`import type`) for parity with vscode

resolves part of #189