### PR TITLE
fix(extra): zathura theme text selection not being transparent

### DIFF
--- a/extra/zathura/vscode-dark
+++ b/extra/zathura/vscode-dark
@@ -15,8 +15,10 @@ set notification-error-fg       "#f44747"
 set notification-warning-bg     "#1e1e1e"
 set notification-warning-fg     "#d7ba7d"
 
-set highlight-color             "#007acc"
-set highlight-active-color      "#d4d4d4"
+set highlight-color             "rgba(0,122,204,0.5)"
+set highlight-active-color      "rgba(215,186,125,0.5)"
+
+set highlight-fg                "#f44747"
 
 set completion-highlight-fg     "#56b6c2"
 set completion-highlight-bg     "#1e1e1e"
@@ -35,3 +37,4 @@ set index-bg                    "#1e1e1e"
 
 set index-active-fg             "#56b6c2"
 set index-active-bg             "#1e1e1e"
+

--- a/extra/zathura/vscode-light
+++ b/extra/zathura/vscode-light
@@ -15,8 +15,10 @@ set notification-error-fg       "#c72e0f"
 set notification-warning-fg     "#795e25"
 set notification-warning-bg     "#ffffff"
 
-set highlight-color             "#007acc"
-set highlight-active-color      "#808080"
+set highlight-color             "rgba(0,122,204,0.5)"
+set highlight-active-color      "rgba(215,186,125,0.5)"
+
+set highlight-fg                "#c72e0f"
 
 set completion-highlight-bg     "#56b6c2"
 set completion-highlight-fg     "#000000"


### PR DESCRIPTION
Recently zathura switched to defining text selection block transparency via the RGBA color value of the selection block, so this fix makes it visible what's behind the selection blocks.

I also made the link numbers red to make them slightly more noticeable (even though it's not ideal as they are always behind the highlighted selection blocks).

![1714914360](https://github.com/Mofiqul/vscode.nvim/assets/52537705/4bb3dcef-7999-4adc-ac5f-7c8ce86a9766)
