### PR TITLE
Support terminal colors

### DIFF
--- a/lua/vscode/config.lua
+++ b/lua/vscode/config.lua
@@ -7,6 +7,7 @@ local defaults = {
     color_overrides = {},
     group_overrides = {},
     disable_nvimtree_bg = true,
+    terminal_colors = true,
 }
 
 config.opts = {}

--- a/lua/vscode/init.lua
+++ b/lua/vscode/init.lua
@@ -4,6 +4,7 @@
 local vscode = {}
 local config = require('vscode.config')
 local theme = require('vscode.theme')
+local utils = require('vscode.utils')
 
 -- Pass setup to config module
 vscode.setup = config.setup
@@ -18,6 +19,9 @@ vscode.load = function(style)
 
     vim.o.termguicolors = true
     vim.g.colors_name = 'vscode'
+    if config.opts.terminal_colors then
+        utils.terminal(require('vscode.colors').get_colors())
+    end
 
     local background = style or config.opts.style
     if background then

--- a/lua/vscode/utils.lua
+++ b/lua/vscode/utils.lua
@@ -1,0 +1,32 @@
+local utils = {}
+
+utils.terminal = function(colors)
+  -- dark
+  vim.g.terminal_color_0 = colors.vscBack
+  vim.g.terminal_color_8 = colors.vscGray
+
+  -- light
+  vim.g.terminal_color_7 = colors.vscFront
+  vim.g.terminal_color_15 = colors.vscFront
+
+  -- colors
+  vim.g.terminal_color_1 = colors.vscRed
+  vim.g.terminal_color_9 = colors.vscRed
+
+  vim.g.terminal_color_2 = colors.vscGreen
+  vim.g.terminal_color_10 = colors.vscGreen
+
+  vim.g.terminal_color_3 = colors.vscYellow
+  vim.g.terminal_color_11 = colors.vscYellow
+
+  vim.g.terminal_color_4 = colors.vscBlue
+  vim.g.terminal_color_12 = colors.vscBlue
+
+  vim.g.terminal_color_5 = colors.vscPink
+  vim.g.terminal_color_13 = colors.vscPink
+
+  vim.g.terminal_color_6 = colors.vscBlueGreen
+  vim.g.terminal_color_14 = colors.vscBlueGreen
+end
+
+return utils


### PR DESCRIPTION
The plugin should set the vim terminal colors. There are many benefits, such as:
- The terminal colors match the reset of neovim
- Neovim guis, such as [neovide](https://github.com/neovide/neovide), wont be stuck with default term colors
- When changing style terminal will update accordingly

Plugins such as [tokyonight.nvim](https://github.com/folke/tokyonight.nvim/blob/c91aef1125e052c9d862e68389e4185ec56f6cde/lua/tokyonight/util.lua#L120-L147) already do this, to great effect. Potentially the colors shouldn't be based on highlight groups, as is the case right now, but rather based directly on the gui term colors.