### PR TITLE
fix builtin tag color

### DIFF
--- a/lua/vscode/theme.lua
+++ b/lua/vscode/theme.lua
@@ -135,6 +135,7 @@ theme.set_highlights = function(opts)
     hl(0, '@type.qualifier', { fg = c.vscBlue, bg = 'NONE' })
     hl(0, '@structure', { fg = c.vscLightBlue, bg = 'NONE' })
     hl(0, '@tag', { fg = c.vscBlue, bg = 'NONE' })
+    hl(0, '@tag.builtin', { fg = c.vscBlue, bg = 'NONE' })
     hl(0, '@tag.delimiter', { fg = c.vscGray, bg = 'NONE' })
     hl(0, '@tag.attribute', { fg = c.vscLightBlue, bg = 'NONE' })
 


### PR DESCRIPTION
https://neovim.io/doc/user/news-0.10.html
> Treesitter highlight groups have been renamed to be more in line with upstream tree-sitter and Helix to make it easier to share queries.

html documents are unaffected but this is noticeable for builtin tags in jsx for example.