### PR TITLE
Add highlight for QuickFixLine 'bold = true'

### DIFF
--- a/lua/vscode/theme.lua
+++ b/lua/vscode/theme.lua
@@ -89,6 +89,7 @@ theme.set_highlights = function(opts)
     hl(0, 'NormalFloat', { bg = c.vscPopupBack })
     hl(0, 'WinBar', { fg = c.vscFront, bg = c.vscBack, bold = true })
     hl(0, 'WinBarNc', { fg = c.vscFront, bg = c.vscBack })
+    hl(0, 'QuickFixLine', { bold = true })
 
     -- Treesitter
     hl(0, '@error', { fg = c.vscRed, bg = 'NONE' }) -- Legacy


### PR DESCRIPTION
After:

![image](https://github.com/Mofiqul/vscode.nvim/assets/16181067/d38a6847-eaa0-422f-91fb-fe13a70ccaf6)

Before: notice that `QuickFixLine` is defined to Neovim 0.10 defaults.

![image](https://github.com/Mofiqul/vscode.nvim/assets/16181067/d9e9efa6-e15c-4e3a-8a78-6fd40627f4c8)
![image](https://github.com/Mofiqul/vscode.nvim/assets/16181067/22d4ffff-3fb8-446f-9b8f-9a973683d41d)
