### PR TITLE
Change class instantiation to a proper color in python.

### DIFF
--- a/lua/vscode/theme.lua
+++ b/lua/vscode/theme.lua
@@ -401,6 +401,7 @@ theme.set_highlights = function(opts)
     hl(0, 'pythonTodo', { fg = c.vscBlue, bg = 'NONE' })
     hl(0, 'pythonClassVar', { fg = c.vscBlue, bg = 'NONE' })
     hl(0, 'pythonClassDef', { fg = c.vscBlueGreen, bg = 'NONE' })
+    hl(0, '@constructor.python', { fg = c.vscBlueGreen, bg = 'NONE' })
 
     -- TeX
     hl(0, 'texStatement', { fg = c.vscBlue, bg = 'NONE' })


### PR DESCRIPTION
Before the change:
<img width="334" alt="Before" src="https://github.com/user-attachments/assets/c7897de6-aca9-4a6b-b7c3-e2ea7bb4619d">

After the change (this aligns with how it is rendered in VS Code):
<img width="315" alt="After" src="https://github.com/user-attachments/assets/8f3db974-5d08-4580-a40a-0a68838d3294">
