### PR TITLE
fix builtin types for most languages

### DIFF
--- a/lua/vscode/theme.lua
+++ b/lua/vscode/theme.lua
@@ -162,7 +162,7 @@ theme.set_highlights = function(opts)
     hl(0, '@diff.delta', { link = 'DiffChange' })
 
     -- LSP semantic tokens
-    hl(0, '@type.builtin', { link = '@type' })
+    hl(0, '@type.builtin', { fg = c.vscBlue, bg = 'NONE' })
     hl(0, '@lsp.typemod.type.defaultLibrary', { link = '@type.builtin' })
     hl(0, '@lsp.type.type', { link = '@type' })
     hl(0, '@lsp.type.typeParameter', { link = '@type' })
@@ -288,6 +288,8 @@ theme.set_highlights = function(opts)
     hl(0, 'jsSpreadExpression', { fg = c.vscLightBlue, bg = 'NONE' })
 
     -- Typescript
+    hl(0, '@type.builtin.typescript', { link = '@type' })
+    hl(0, '@type.builtin.tsx', { link = '@type' })
     hl(0, 'typescriptLabel', { fg = c.vscLightBlue, bg = 'NONE' })
     hl(0, 'typescriptExceptions', { fg = c.vscLightBlue, bg = 'NONE' })
     hl(0, 'typescriptBraces', { fg = c.vscFront, bg = 'NONE' })


### PR DESCRIPTION
Originally created https://github.com/Mofiqul/vscode.nvim/pull/206 but then I realized it wasn't just a csharp issue.

Source of the issue seems to be here:

https://github.com/Mofiqul/vscode.nvim/commit/a311cb35dc8a7c60d4b6aef7893c83a826672993#diff-a747bcbf55d2d7232db9cda34350bf95810506ae5d16f00ae104b353321dd35aR162

> Nvim linked @type.builtin to Special by default.

I think typescript is one of the few languages that vscode highlights this way. Seems like for most other languages, blue is used for builtin types.