### PR TITLE
feat(extra): fzf color scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ require("bufferline").setup({
 
 - [Alacritty](https://github.com/alacritty/alacritty) color scheme
 - [Foot](https://codeberg.org/dnkl/foot) color scheme
+- [fzf](https://junegunn.github.io/fzf/) color scheme
 - [galaxyline.nvim](https://github.com/glepnir/galaxyline.nvim) theme
 - [i3](https://i3wm.org/) color scheme
 - [Kitty](https://sw.kovidgoyal.net/kitty/) color scheme

--- a/extra/fzf/vscode-dark
+++ b/extra/fzf/vscode-dark
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+
+# Visual Studio Code dark color scheme for fzf
+
+# Generated using https://vitormv.github.io/fzf-themes#eyJjb2xvcnMiOiJmZzojZDRkNGQ0LGZnKzojZDRkNGQ0LGJnOiMxZjFmMWYsYmcrOiMyMjIyMjIsaGw6IzYwOGI0ZSxobCs6I0M1ODZDMCxpbmZvOiNDNTg2QzAsbWFya2VyOiNDNTg2QzAscHJvbXB0OiNDNTg2QzAsc3Bpbm5lcjojQzU4NkMwLHBvaW50ZXI6I0M1ODZDMCxoZWFkZXI6IzYwOGI0ZSxib3JkZXI6IzgwODA4MCxsYWJlbDojQzU4NkMwLHF1ZXJ5OiNkNGQ0ZDQifQ==
+
+# .profile, .bash_profile, .zshenv
+
+export FZF_DEFAULT_OPTS="$FZF_DEFAULT_OPTS"'
+  --color=fg:#d4d4d4,fg+:#d4d4d4,bg:#1f1f1f,bg+:#222222
+  --color=hl:#608b4e,hl+:#C586C0,info:#C586C0,marker:#C586C0
+  --color=prompt:#C586C0,spinner:#C586C0,pointer:#C586C0,header:#608b4e
+  --color=border:#808080,label:#C586C0,query:#d4d4d4'

--- a/extra/fzf/vscode-light
+++ b/extra/fzf/vscode-light
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+
+# Visual Studio Code light color scheme for fzf
+
+# Generated using https://vitormv.github.io/fzf-themes#eyJjb2xvcnMiOiJmZzojMDAwMDAwLGZnKzojMDAwMDAwLGJnOiNGRkZGRkYsYmcrOiNGM0YzRjMsaGw6IzAwODAwMCxobCs6I0FGMDBEQixpbmZvOiNBRjAwREIsbWFya2VyOiNBRjAwREIscHJvbXB0OiNBRjAwREIsc3Bpbm5lcjojQUYwMERCLHBvaW50ZXI6I0FGMDBEQixoZWFkZXI6IzAwODAwMCxib3JkZXI6IzAwMDAwMCxsYWJlbDojQUYwMERCLHF1ZXJ5OiMwMDAwMDAifQ==
+
+# .profile, .bash_profile, .zshenv
+
+export FZF_DEFAULT_OPTS="$FZF_DEFAULT_OPTS"'
+  --color=fg:#000000,fg+:#000000,bg:#FFFFFF,bg+:#F3F3F3
+  --color=hl:#008000,hl+:#AF00DB,info:#AF00DB,marker:#AF00DB
+  --color=prompt:#AF00DB,spinner:#AF00DB,pointer:#AF00DB,header:#008000
+  --color=border:#000000,label:#AF00DB,query:#000000'


### PR DESCRIPTION
Styled according to how fzf looks with vscode.nvim colors applied according to a snippet from the fzf-lua plugin docs: https://github.com/ibhagwan/fzf-lua/blob/86b77a661ff38bf08b1ceb5a6c3c257285a42a4d/doc/fzf-lua.txt#L810C1-L810C26