### PR TITLE
Improve Neogit highlights

### DIFF
--- a/lua/vscode/theme.lua
+++ b/lua/vscode/theme.lua
@@ -649,22 +649,23 @@ theme.set_highlights = function(opts)
     hl(0, 'MiniStatuslineFileinfo', { bg = c.vscLeftLight, fg = c.vscFront })
     hl(0, 'MiniStatuslineInactive', { bg = c.vscLeftDark, fg = c.vscFront })
 
-	-- Neotree
-	hl(0, 'NeoTreeBufferNumber', { fg = c.vscLineNumber, bg = 'NONE' })
-	hl(0, 'NeoTreeCursorLine', { fg = 'NONE', bg = c.vscCursorDarkDark })
-	hl(0, 'NeoTreeDimText', { fg = 'NONE', bg = c.vscCursorDarkDark })
-	hl(0, 'NeoTreeDirectoryIcon', { fg = c.vscBlue, bg = 'NONE' })
-	hl(0, 'NeoTreeDirectoryName', { fg = c.vscFront, bg = 'NONE' })
-	hl(0, 'NeoTreeDotfile', { fg = c.vscDisabledBlue, bg = 'NONE' })
-	hl(0, 'NeoTreeFileIcon', { fg = c.vscViolet, bg = 'NONE' })
-	hl(0, 'NeoTreeFileName', { fg = c.vscFront, bg = 'NONE' })
-	hl(0, 'NeoTreeFileNameOpened', { fg = c.vscFront, bg = c.vscCursorDarkDark })
-	hl(0, 'NeoTreeFilterTerm', { fg = c.vscFront, bg = 'NONE' })
-	hl(0, 'NeoTreeFloatBorder', { fg = c.vscLineNumber, bg = 'NONE' })
-	hl(0, 'NeoTreeFloatTitle', { fg = c.vscLineNumber, bg = 'NONE' })
-	hl(0, 'NeoTreeTitleBar', { fg = c.vscLineNumber, bg = 'NONE' })
+    -- Neotree
+    hl(0, 'NeoTreeBufferNumber', { fg = c.vscLineNumber, bg = 'NONE' })
+    hl(0, 'NeoTreeCursorLine', { fg = 'NONE', bg = c.vscCursorDarkDark })
+    hl(0, 'NeoTreeDimText', { fg = 'NONE', bg = c.vscCursorDarkDark })
+    hl(0, 'NeoTreeDirectoryIcon', { fg = c.vscBlue, bg = 'NONE' })
+    hl(0, 'NeoTreeDirectoryName', { fg = c.vscFront, bg = 'NONE' })
+    hl(0, 'NeoTreeDotfile', { fg = c.vscDisabledBlue, bg = 'NONE' })
+    hl(0, 'NeoTreeFileIcon', { fg = c.vscViolet, bg = 'NONE' })
+    hl(0, 'NeoTreeFileName', { fg = c.vscFront, bg = 'NONE' })
+    hl(0, 'NeoTreeFileNameOpened', { fg = c.vscFront, bg = c.vscCursorDarkDark })
+    hl(0, 'NeoTreeFilterTerm', { fg = c.vscFront, bg = 'NONE' })
+    hl(0, 'NeoTreeFloatBorder', { fg = c.vscLineNumber, bg = 'NONE' })
+    hl(0, 'NeoTreeFloatTitle', { fg = c.vscLineNumber, bg = 'NONE' })
+    hl(0, 'NeoTreeTitleBar', { fg = c.vscLineNumber, bg = 'NONE' })
 
     -- NeogitOrg/neogit
+    hl(0, 'NeogitWinSeparator', { link = 'WinSeparator' })
     if isDark then
         hl(0, 'NeogitDiffAdd', { fg = c.vscGitAdded, bg = c.vscDiffGreenDark })
         hl(0, 'NeogitDiffAddHighlight', { fg = c.vscGitAdded, bg = c.vscDiffGreenLight })
@@ -688,6 +689,12 @@ theme.set_highlights = function(opts)
         hl(0, 'NeogitHunkHeader', { fg = c.vscGitModified, bg = c.vscLeftMid })
         hl(0, 'NeogitHunkHeaderHighlight', { fg = c.vscGitModified, bg = c.vscLeftDark })
     end
+    -- Cursor line highlights cause way too much distraction; rely on the
+    -- pointer and regular highlight colors:
+    hl(0, 'NeogitDiffAddCursor', { link = 'NeogitDiffAddHighlight' })
+    hl(0, 'NeogitDiffContextCursor', { link = 'NeogitDiffContextHighlight' })
+    hl(0, 'NeogitDiffDeleteCursor', { link = 'NeogitDiffDeleteHighlight' })
+    hl(0, 'NeogitHunkHeaderCursor', { link = 'NeogitHunkHeaderHighlight' })
 
     if isDark then
         hl(0, 'NvimTreeFolderIcon', { fg = c.vscBlue, bg = 'NONE' })


### PR DESCRIPTION
These changes reduce the shifting of colors that happens as one navigates hunks with the cursor on a `NeogitStatus` buffer. It reduces accessibility a tiny bit (by not showing a cursor line highlight inside hunks) but makes the theme look less broken and makes it easier to follow what's going on.

![image](https://github.com/user-attachments/assets/23f7e0bb-973d-4d9c-af40-dd2a48363cda)
