### PR TITLE
fix(alacritty): colors

### DIFF
--- a/extra/alacritty/vscode-dark.toml
+++ b/extra/alacritty/vscode-dark.toml
@@ -14,10 +14,10 @@ cursor = "#D4D4D4"
 black = "#1F1F1F"
 red = "#F44747"
 green = "#6A9955"
-yellow = "#795E26"
-blue = "#007ACC"
+yellow = "#DCDCAA"
+blue = "#569CD6"
 magenta = "#C586C0"
-cyan = "#4FC1FF"
+cyan = "#56B6C2"
 white = "#D4D4D4"
 
 [colors.bright]

--- a/extra/alacritty/vscode-light.toml
+++ b/extra/alacritty/vscode-light.toml
@@ -16,8 +16,8 @@ red = "#F44747"
 green = "#6A9955"
 yellow = "#795E26"
 blue = "#007ACC"
-magenta = "#C586C0"
-cyan = "#e34ffe"
+magenta = "#AF00DB"
+cyan = "#56B6C2"
 white = "#D4D4D4"
 
 [colors.bright]


### PR DESCRIPTION
Some of the colors in the alacritty themes were either from the wrong variant, or just the wrong color. This brings alacritty in-line with the kitty theme.