### PR TITLE
Copilot highlight now also works in dark mode

### DIFF
--- a/lua/vscode/colors.lua
+++ b/lua/vscode/colors.lua
@@ -55,6 +55,8 @@ colors.get_colors = function()
 
             vscFoldBackground = '#202d39',
 
+            vscSuggestion = '#6A6A6A',
+
             -- Syntax colors
             vscGray = '#808080',
             vscViolet = '#646695',
@@ -130,6 +132,8 @@ colors.get_colors = function()
             vscContextCurrent = '#929292',
 
             vscFoldBackground = '#e6f3ff',
+
+            vscSuggestion = '#868686',
 
             -- Syntax colors
             vscGray = '#000000',

--- a/lua/vscode/theme.lua
+++ b/lua/vscode/theme.lua
@@ -759,6 +759,9 @@ theme.set_highlights = function(opts)
     hl(0, 'MiniStatuslineModeReplace', { fg = c.vscBack, bg = c.vscYellowOrange, bold = true })
     hl(0, 'MiniStatuslineModeVisual', { fg = c.vscBack, bg = c.vscPink, bold = true })
 
+    -- Copilot
+    hl(0, 'CopilotSuggestion', { fg = c.vscSuggestion, bg = 'NONE' })
+
     -- NeogitOrg/neogit
     hl(0, 'NeogitWinSeparator', { link = 'WinSeparator' })
     if isDark then
@@ -869,9 +872,6 @@ theme.set_highlights = function(opts)
         hl(0, 'CocFloating', { fg = 'NONE', bg = c.vscPopupBack })
         hl(0, 'CocMenuSel', { fg = '#FFFFFF', bg = '#285EBA' })
         hl(0, 'CocSearch', { fg = '#2A64B9', bg = 'NONE' })
-
-        -- Copilot
-        hl(0, 'CopilotSuggestion', { fg = c.vscGray, bg = 'NONE' })
 
         -- symbols-outline
         -- white fg and lualine blue bg


### PR DESCRIPTION
In dark mode, copilot took on the same colors as the non-suggestion highlight. The copilot highlight was only defined in the `!isDark` section.
Colors are taken from VsCode light and dark themes.