### PR TITLE
revert cursorline/colorcolumn breaking change

### DIFF
--- a/lua/vscode/colors.lua
+++ b/lua/vscode/colors.lua
@@ -25,7 +25,7 @@ colors.get_colors = function()
             vscSplitDark = '#444444',
             vscSplitThumb = '#424242',
 
-            vscCursorDarkDark = '#363636',
+            vscCursorDarkDark = '#222222',
             vscCursorDark = '#51504F',
             vscCursorLight = '#AEAFAD',
             vscSelection = '#264F78',


### PR DESCRIPTION
I feel like [this change](https://github.com/Mofiqul/vscode.nvim/commit/396dd65c14275e54e388d49d8a08871448880407#diff-932a387ba84163d24624ebd618f36c5477edcad607e5385b76a263f679a459faL28) makes `cursorline` and `colorcolumn` too staggering and that it shouldn't be a default.
@Mofiqul, do you mind clarifying why it was made this way?

Without this PR:
![before_change](https://github.com/user-attachments/assets/d5dd8c19-2348-4edf-9b81-26d36b49b916)
With this PR:
![after_change](https://github.com/user-attachments/assets/0255e596-d46e-47b2-91db-8f8e9c0c46c2)
