### PR TITLE
feat: add ability to enable italic inlay type hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ require('vscode').setup({
     -- Enable italic comment
     italic_comments = true,
 
+    -- Enable italic inlay type hints
+    italic_inlayhints = true,
+
     -- Underline `@markup.link.*` variants
     underline_links = true,
 

--- a/lua/vscode/config.lua
+++ b/lua/vscode/config.lua
@@ -3,6 +3,7 @@ local config = {}
 local defaults = {
     transparent = false,
     italic_comments = false,
+    italic_inlayhints = false,
     underline_links = false,
     color_overrides = {},
     group_overrides = {},
@@ -18,6 +19,7 @@ config.setup = function(user_opts)
     local global_settings_opts = vim.tbl_extend('force', defaults, {
         transparent = (vim.g.vscode_transparent == true or vim.g.vscode_transparent == 1),
         italic_comments = (vim.g.vscode_italic_comment == true or vim.g.vscode_italic_comment == 1),
+        italic_inlayhints = (vim.g.vscode_italic_inlayhints == true or vim.g.vscode_italic_inlayhints == 1),
         underline_links = (vim.g.vscode_underline_links == true or vim.g.vscode_underline_links == 1),
         disable_nvimtree_bg = (vim.g.vscode_disable_nvim_tree_bg == true or vim.g.vscode_disable_nvim_tree_bg == 1),
     })

--- a/lua/vscode/theme.lua
+++ b/lua/vscode/theme.lua
@@ -569,6 +569,7 @@ theme.set_highlights = function(opts)
     hl(0, 'LspReferenceText', { fg = 'NONE', bg = isDark and c.vscPopupHighlightGray or c.vscPopupHighlightLightBlue })
     hl(0, 'LspReferenceRead', { fg = 'NONE', bg = isDark and c.vscPopupHighlightGray or c.vscPopupHighlightLightBlue })
     hl(0, 'LspReferenceWrite', { fg = 'NONE', bg = isDark and c.vscPopupHighlightGray or c.vscPopupHighlightLightBlue })
+    hl(0, 'LspInlayHint', { fg = c.vscSuggestion, bg = 'NONE', italic = opts.italic_inlayhints })
 
     -- Trouble
     hl(0, 'TroubleNormal', { link = 'Normal' })


### PR DESCRIPTION
Hi! 👋
I’d like to propose a small enhancement: the ability to enable italic style for inlay type hints, similar to how it's currently done for comments.

I’ve added a new config option called italic_inlayhints, add the LspInlayHint style in the LSP section accordingly, and also made sure to update the README.md with info about this new option.

- Before:
![image](https://github.com/user-attachments/assets/300e4c6c-bf44-4af2-8619-f4fba4360415)

- After, with enabled `italic_inlayhints`:
![image](https://github.com/user-attachments/assets/3f530c8a-f2ff-409a-9526-13adcb84fa19)

