### PR TITLE
feat: add support for Snacks.indent

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ vscode.nvim (formerly `codedark.nvim`) is a Lua port of [vim-code-dark](https://
 - [vim-illuminate](https://github.com/RRethy/vim-illuminate)
 - [rainbow-delimiters](https://gitlab.com/HiPhish/rainbow-delimiters.nvim)
 - [which-key](https://github.com/folke/which-key.nvim)
+- [Snacks.indent](https://github.com/folke/snacks.nvim/blob/main/docs/indent.md)
 
 ## ⬇️ Installation
 

--- a/lua/vscode/theme.lua
+++ b/lua/vscode/theme.lua
@@ -538,6 +538,10 @@ theme.set_highlights = function(opts)
     hl(0, 'IblWhitespace', { fg = c.vscContext, bg = 'NONE', nocombine = true })
     hl(0, 'IblScope', { fg = c.vscContextCurrent, bg = 'NONE', nocombine = true })
 
+    -- Snacks.indent
+    hl(0, 'SnacksIndent', { fg = c.vscContext, bg = 'NONE', nocombine = true })
+    hl(0, 'SnacksIndentScope', { fg = c.vscContextCurrent, bg = 'NONE', nocombine = true })
+
     -- Neotest
     hl(0, 'NeotestAdapterName', { fg = c.vscFront, bold = true })
     hl(0, 'NeotestDir', { fg = c.vscBlue })


### PR DESCRIPTION
Add support for [`Snacks.indent`](https://github.com/folke/snacks.nvim/blob/main/docs/indent.md) (same highlighting as Indent Blankline).