### PR TITLE
feat: add support for Snacks.dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ vscode.nvim (formerly `codedark.nvim`) is a Lua port of [vim-code-dark](https://
 - [vim-illuminate](https://github.com/RRethy/vim-illuminate)
 - [rainbow-delimiters](https://gitlab.com/HiPhish/rainbow-delimiters.nvim)
 - [which-key](https://github.com/folke/which-key.nvim)
+- [Snacks.dashboard](https://github.com/folke/snacks.nvim/blob/main/docs/dashboard.md)
 
 ## ⬇️ Installation
 

--- a/lua/vscode/theme.lua
+++ b/lua/vscode/theme.lua
@@ -698,6 +698,14 @@ theme.set_highlights = function(opts)
     hl(0, 'DashboardKey', { fg = c.vscWhite, bg = 'NONE' })
     hl(0, 'DashboardFooter', { fg = c.vscBlue, bg = 'NONE', italic = true })
 
+    -- Snacks.Dashboard
+    hl(0, 'SnacksDashboardHeader', { fg = c.vscBlue, bg = 'NONE' })
+    hl(0, 'SnacksDashboardDesc', { fg = c.vscYellow, bg = 'NONE' })
+    hl(0, 'SnacksDashboardIcon', { fg = c.vscYellowOrange, bg = 'NONE' })
+    hl(0, 'SnacksDashboardKey', { fg = c.vscPink, bg = 'NONE' })
+    hl(0, 'SnacksDashboardFooter', { fg = c.vscBlue, bg = 'NONE', italic = true })
+    hl(0, 'SnacksDashboardSpecial', { fg = c.vscYellowOrange, bg = 'NONE', italic = true })
+
     -- Illuminate
     hl(0, 'illuminatedWord', { bg = isDark and c.vscPopupHighlightGray or c.vscPopupHighlightLightBlue })
     hl(0, 'illuminatedCurWord', { bg = isDark and c.vscPopupHighlightGray or c.vscPopupHighlightLightBlue })


### PR DESCRIPTION
Add support for [Snacks.dashboard](https://github.com/folke/snacks.nvim/blob/main/docs/dashboard.md) (similar highlighting as for existing Dashboard support):

<img width="730" height="530" alt="image" src="https://github.com/user-attachments/assets/f488fbf2-84ed-48a4-9821-3579032e36a9" />
